### PR TITLE
Allow BDAY to be in the extended format of ISO 8601

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -288,7 +288,7 @@ class CarddavObject:
             :rtype: datetime.datetime
         """
         try:
-            return datetime.datetime.strptime(self.vcard.bday.value, "%Y%m%d")
+            return datetime.datetime.strptime(self.vcard.bday.value.replace('-', ''), "%Y%m%d")
         except AttributeError as e:
             return None
         except ValueError as e:


### PR DESCRIPTION
Thank you for this interesting project. I recently started using it and noticed the following issue.

The BDAY field can either be in the format BDAY:19950415 or BDAY:1995-04-15 (see http://www.imc.org/pdi/vcard-21.txt in Section Birthdate).

khard currently only supports the format without hyphens. This is a problem since e.g. Thunderbird and Android create contacts in the extended format with hyphens (however, they can read both formats) and as a result their birthday field is ignored by khard.

This merge request allows khard to read both formats.