### PR TITLE
Add Zsh completion definition

### DIFF
--- a/misc/_khard
+++ b/misc/_khard
@@ -1,0 +1,23 @@
+#compdef khard
+
+# Zsh completion definition.
+# Install by copying to a directory where zsh searches for completion
+# functions (the $fpath array).
+
+local curcontext="$curcontext"
+local -a state line expl
+local -A opt_args
+
+_arguments -s \
+  {-a+,--addressbook=}'[specify addressbook]:addressbook:->addressbooks' \
+  {-r,--reverse}'[sort contacts in reverse order]' \
+  {-s+,--search=}'[search for contacts]:search string' \
+  {-t+,--sort=}'[sort contacts list]:order:(alphabetical addressbook)' \
+  '(- 1)'{-h,--help}'[show help information]' \
+  '(- 1)'{-v,--version}'[show version information]' \
+  '1:action:(list details source mutt alot phone new add-email merge modify copy move remove)' && return
+
+if [[ -n $state ]]; then
+  _sequence _wanted addressbooks expl "addressbook" compadd - \
+      ${${=${"$(_call_program addressbooks ${words[1]} -a , 2>&1)"}##*:}//,/}
+fi


### PR DESCRIPTION
This adds a file for zsh completions so zsh users will get options, actions and addressbooks completed after khard instead of filenames. Would be nice if it could be included.