### PR TITLE
Correct query_command in mutt documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Khard may be used as an external address book for the email client mutt. To acco
 following to your mutt config file (mostly ~/.mutt/muttrc):
 
 ```
-set query_command= "khard email -p %s"
+set query_command= "khard email %s"
 bind editor <Tab> complete-query
 bind editor ^T    complete
 ```


### PR DESCRIPTION
This PR correct a typo the mutt section of the documentation. `khard email -p %s` shows a "pretty" display which doesn't work in mutt. `khard email %s` is working just fine.