### PR TITLE
setup.py: decode the readme explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     author_email = 'email@eric-scheibler.de',
     url = 'https://github.com/scheibler/khard/',
     description = 'A console carddav client',
-    long_description = open('README.md').read(),
+    long_description = open('README.md', 'rb').read().decode('utf-8'),
     license = 'GPL',
     keywords = 'Carddav console addressbook',
     classifiers = [


### PR DESCRIPTION
If the LANG environment doesn't use UTF-8, we need to tell Python that
it isn't whatever it says it is explicitly.