### PR TITLE
Add a test suite and a first test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "nightly" # currently points to 3.7-dev
+install: python setup.py install
+before_script:
+  - mkdir -p ~/.config/khard
+  - cp misc/khard/khard.conf.example ~/.config/khard/khard.conf
+  - mkdir -p ~/.contacts/family
+  - mkdir -p ~/.contacts/friends
+script: python -m unittest discover

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -1125,7 +1125,7 @@ def copy_or_move_subcommand(action, vcard_list, target_address_book_list):
                     break
 
 
-def parse_args():
+def parse_args(argv):
     """Parse the command line arguments and return the namespace that was
     creates by argparse.ArgumentParser.parse_args().
 
@@ -1404,7 +1404,7 @@ def parse_args():
     # Parese the command line with the first argument parser.  It will handle
     # the config option (its main job) and also the help, version and debug
     # options as these do not depend on anything else.
-    args = first_parser.parse_args()
+    args = first_parser.parse_args(argv)
     remainder = args.remainder
 
     # Set the loglevel to debug if given on the command line.  This is done
@@ -1438,8 +1438,8 @@ def parse_args():
     return args
 
 
-def main():
-    args = parse_args()
+def main(argv=sys.argv[1:]):
+    args = parse_args(argv)
 
     # if args.action isn't one of the defined actions, it must be an alias
     if args.action not in Actions.get_list_of_all_actions():

--- a/setup.py
+++ b/setup.py
@@ -52,4 +52,5 @@ setup(
     entry_points = {
         'console_scripts': [ 'khard = khard.khard:main' ]
     },
+    test_suite = "test",
 )

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,10 @@
+"""Module to make it possible to import the test folder as a python package and
+hence make it possible to run all unittests from the top level direcotry with
+
+        python -m unittest [discover]
+
+and
+
+        python setup.py test
+
+"""

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -1,33 +1,47 @@
 """Test some features of the command line interface of khard."""
 
+import io
 import os
 import subprocess
+import sys
 import unittest
+
+from khard import khard
 
 
 class HelpOption(unittest.TestCase):
 
     def setUp(self):
+        self.stdout = sys.stdout
+        self.output = io.StringIO()
+        sys.stdout = self.output
         self.env = dict(os.environ)
         self.env['PYTHONPATH'] = '.'
 
-    def test_global_help(self):
+    def tearDown(self):
+        self.output.close()
+        sys.stdout = self.stdout
+
+    def test_khard_runner_script(self):
         output = subprocess.check_output(['./khard-runner.py', '-h'],
                                          env=self.env)
         line = output.splitlines()[0]
         self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
 
+    def test_global_help(self):
+        self.assertRaises(SystemExit, khard.main, ['-h'])
+        text = self.output.getvalue().splitlines()
+        self.assertRegex(text[0], r'^usage: setup.py \[-h\]')
+
     def test_subcommand_help(self):
-        output = subprocess.check_output(['./khard-runner.py', 'list', '-h'],
-                                         env=self.env)
-        line = output.splitlines()[0]
-        self.assertTrue(line.startswith(b'usage: khard-runner.py list [-h]'))
+        self.assertRaises(SystemExit, khard.main, ['list', '-h'])
+        text = self.output.getvalue().splitlines()
+        self.assertTrue(text[0].startswith('usage: setup.py list [-h]'))
 
     def test_global_help_with_subcommand(self):
-        output = subprocess.check_output(['./khard-runner.py', '-h', 'list'],
-                                         env=self.env)
-        line = output.splitlines()[0]
-        self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
+        self.assertRaises(SystemExit, khard.main, ['-h', 'list'])
+        text = self.output.getvalue().splitlines()
+        self.assertRegex(text[0], r'^usage: setup.py \[-h\]')
 
 
 if __name__ == "__main__":

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -1,0 +1,34 @@
+"""Test some features of the command line interface of khard."""
+
+import os
+import subprocess
+import unittest
+
+
+class HelpOption(unittest.TestCase):
+
+    def setUp(self):
+        self.env = dict(os.environ)
+        self.env['PYTHONPATH'] = '.'
+
+    def test_global_help(self):
+        output = subprocess.check_output(['./khard-runner.py', '-h'],
+                                         env=self.env)
+        line = output.splitlines()[0]
+        self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
+
+    def test_subcommand_help(self):
+        output = subprocess.check_output(['./khard-runner.py', 'list', '-h'],
+                                         env=self.env)
+        line = output.splitlines()[0]
+        self.assertTrue(line.startswith(b'usage: khard-runner.py list [-h]'))
+
+    def test_global_help_with_subcommand(self):
+        output = subprocess.check_output(['./khard-runner.py', '-h', 'list'],
+                                         env=self.env)
+        line = output.splitlines()[0]
+        self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -12,12 +12,6 @@ from khard import khard
 
 class HelpOption(unittest.TestCase):
 
-    def test_khard_runner_script(self):
-        output = subprocess.check_output(['./khard-runner.py', '-h'],
-                                         env={'PYTHONPATH': '.'})
-        line = output.splitlines()[0]
-        self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
-
     def test_global_help(self):
         stdout = io.StringIO()
         with mock.patch("sys.stdout", stdout):

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -31,17 +31,18 @@ class HelpOption(unittest.TestCase):
     def test_global_help(self):
         self.assertRaises(SystemExit, khard.main, ['-h'])
         text = self.output.getvalue().splitlines()
-        self.assertRegex(text[0], r'^usage: setup.py \[-h\]')
+        self.assertRegex(text[0], r'^usage: {} \[-h\]'.format(sys.argv[0]))
 
     def test_subcommand_help(self):
         self.assertRaises(SystemExit, khard.main, ['list', '-h'])
         text = self.output.getvalue().splitlines()
-        self.assertTrue(text[0].startswith('usage: setup.py list [-h]'))
+        self.assertRegex(text[0], r'^usage: {} list \[-h\]'.format(
+            sys.argv[0]))
 
     def test_global_help_with_subcommand(self):
         self.assertRaises(SystemExit, khard.main, ['-h', 'list'])
         text = self.output.getvalue().splitlines()
-        self.assertRegex(text[0], r'^usage: setup.py \[-h\]')
+        self.assertRegex(text[0], r'^usage: {} \[-h\]'.format(sys.argv[0]))
 
 
 if __name__ == "__main__":

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -5,43 +5,42 @@ import os
 import subprocess
 import sys
 import unittest
+import unittest.mock as mock
 
 from khard import khard
 
 
 class HelpOption(unittest.TestCase):
 
-    def setUp(self):
-        self.stdout = sys.stdout
-        self.output = io.StringIO()
-        sys.stdout = self.output
-        self.env = dict(os.environ)
-        self.env['PYTHONPATH'] = '.'
-
-    def tearDown(self):
-        self.output.close()
-        sys.stdout = self.stdout
-
     def test_khard_runner_script(self):
         output = subprocess.check_output(['./khard-runner.py', '-h'],
-                                         env=self.env)
+                                         env={'PYTHONPATH': '.'})
         line = output.splitlines()[0]
         self.assertTrue(line.startswith(b'usage: khard-runner.py [-h]'))
 
     def test_global_help(self):
-        self.assertRaises(SystemExit, khard.main, ['-h'])
-        text = self.output.getvalue().splitlines()
+        stdout = io.StringIO()
+        with mock.patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit):
+                khard.main(['-h'])
+        text = stdout.getvalue().splitlines()
         self.assertRegex(text[0], r'^usage: {} \[-h\]'.format(sys.argv[0]))
 
     def test_subcommand_help(self):
-        self.assertRaises(SystemExit, khard.main, ['list', '-h'])
-        text = self.output.getvalue().splitlines()
+        stdout = io.StringIO()
+        with mock.patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit):
+                khard.main(['list', '-h'])
+        text = stdout.getvalue().splitlines()
         self.assertRegex(text[0], r'^usage: {} list \[-h\]'.format(
             sys.argv[0]))
 
     def test_global_help_with_subcommand(self):
-        self.assertRaises(SystemExit, khard.main, ['-h', 'list'])
-        text = self.output.getvalue().splitlines()
+        stdout = io.StringIO()
+        with mock.patch("sys.stdout", stdout):
+            with self.assertRaises(SystemExit):
+                khard.main(['-h', 'list'])
+        text = stdout.getvalue().splitlines()
         self.assertRegex(text[0], r'^usage: {} \[-h\]'.format(sys.argv[0]))
 
 


### PR DESCRIPTION
If the infrastructure is in place we can start to add tests for different things.

The first things that come to mind (and that might already be somewhat complicatet) are
- parsing config files
- parsing example vcard files
- exporting and reimporting contacts

If we write tests that interact with the vcard store and the config file we have to take care to _never_ use the config file and vcards of the user.

Fixes #62.
