### PR TITLE
More object oriented address book

### DIFF
--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -278,7 +278,7 @@ class VdirAddressBook(AddressBook):
         :returns: the number of successfully loaded cards and the number of
             errors
         :rtype: int, int
-
+        :throws: AddressBookParseError
         """
         if self.loaded:
             return len(self.contacts), 0

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -21,22 +21,16 @@ class AddressBook(metaclass=abc.ABCMeta):
 
     """The base class of all address book implementations."""
 
-    def __init__(self, name, path):
+    def __init__(self, name):
         """
         :param name: the name to identify the address book
         :type name: str
-        :param path: the path to the backing structure on disk
-        :type path: str
         """
         self.loaded = False
         self.contacts = []
         self._uids = None
         self._short_uids = None
         self.name = name
-        self.path = os.path.expanduser(path)
-        if not os.path.isdir(self.path):
-            raise FileNotFoundError("[Errno 2] The path {} to the address book"
-                                    " {} does not exist.".format(path, name))
 
     def __str__(self):
         return self.name
@@ -230,6 +224,19 @@ class VdirAddressBook(AddressBook):
 
     """Holds the contacts inside one address book folder.  On disk they are
     stored in vcard files."""
+
+    def __init__(self, name, path):
+        """
+        :param name: the name to identify the address book
+        :type name: str
+        :param path: the path to the backing structure on disk
+        :type path: str
+        """
+        self.path = os.path.expanduser(path)
+        if not os.path.isdir(self.path):
+            raise FileNotFoundError("[Errno 2] The path {} to the address book"
+                                    " {} does not exist.".format(path, name))
+        super().__init__(name)
 
     def _find_vcard_files(self, search=None):
         """Find all vcard files inside this address book.  If a search string

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -163,13 +163,13 @@ class AddressBook(metaclass=abc.ABCMeta):
                 if uid:
                     if uid in self._uids:
                         logging.warning("The contacts %s and %s from address "
-                                        "book %s have the same UID %s", contact,
-                                        self._uids[uid], self, uid)
+                                        "book %s have the same UID %s",
+                                        contact, self._uids[uid], self, uid)
                     else:
                         self._uids[uid] = contact
                 else:
-                    logging.warning("The contact %s from address book %s has no "
-                                    "UID", contact, self)
+                    logging.warning("The contact %s from address book %s has "
+                                    "no UID", contact, self)
         return self._uids
 
     def get_short_uid_dict(self):
@@ -193,16 +193,16 @@ class AddressBook(metaclass=abc.ABCMeta):
                 # seperatly.
                 item0, item1 = sorted_uids[:2]
                 same1 = self._compare_uids(item0, item1)
-                self._short_uids[item0[:same1+1]] = self._uids[item0]
+                self._short_uids[item0[:same1 + 1]] = self._uids[item0]
                 for item_new in sorted_uids[2:]:
                     # shift the items and the common prefix lenght one further
                     item0, item1 = item1, item_new
                     same0, same1 = same1, self._compare_uids(item0, item1)
                     # compute the final prefix length for item1
                     same = max(same0, same1)
-                    self._short_uids[item0[:same+1]] = self._uids[item0]
+                    self._short_uids[item0[:same + 1]] = self._uids[item0]
                 # Save the last item.
-                self._short_uids[item1[:same1+1]] = self._uids[item1]
+                self._short_uids[item1[:same1 + 1]] = self._uids[item1]
         return self._short_uids
 
     @abc.abstractmethod
@@ -289,7 +289,7 @@ class VdirAddressBook(AddressBook):
         if skip:
             logging.warning(
                 "%d of %d vCard files of address book %s could not be parsed.",
-                errors, len(self.contacts)+errors, self)
+                errors, len(self.contacts) + errors, self)
         if len(self.contacts) != len(self.get_uids_dict()):
             logging.warning("There are duplicate UIDs in the address book %s.",
                             self)
@@ -306,8 +306,8 @@ class AddressBookCollection(AddressBook):
         """
         :param name: the name to identify the address book
         :type name: str
-        :param *args: two-tuples, each holding the arguments for one AddressBook
-            instance
+        :param *args: two-tuples, each holding the arguments for one
+            AddressBook instance
         :type *args: tuple(str,str)
         """
         self.loaded = False

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -110,13 +110,14 @@ class AddressBook(metaclass=abc.ABCMeta):
         :rtype: generator(carddav_object.CarddavObject)
 
         """
-        contacts = []
+        found = False
         # Search for contacts with uid == query.
         for contact in self.contacts:
             if contact.get_uid() == query:
+                found = True
                 yield contact
         # If that fails, search for contacts where uid starts with query.
-        if not contacts:
+        if not found:
             for contact in self.contacts:
                 if contact.get_uid().startswith(query):
                     yield contact

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -318,11 +318,7 @@ class AddressBookCollection(AddressBook):
             AddressBook instance
         :type *args: tuple(str,str)
         """
-        self.loaded = False
-        self.contacts = []
-        self._uids = None
-        self._short_uids = None
-        self.name = name
+        super().__init__(name)
         self._abooks = []
         for arguments in args:
             self._abooks.append(VdirAddressBook(*arguments))

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -31,6 +31,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         self.loaded = False
         self.contacts = []
         self._uids = None
+        self._short_uids = None
         self.name = name
         self.path = os.path.expanduser(path)
         if not os.path.isdir(self.path):

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """A simple class to load and manage the vcard files from disk."""
 
+import abc
 import glob
 import logging
 import os
@@ -9,30 +10,139 @@ import re
 from .carddav_object import CarddavObject
 
 
-class AddressBook:
+class AddressBook(metaclass=abc.ABCMeta):
 
-    """Holds the contacts inside one address book folder.  On disk they are
-    stored in vcard files."""
+    """The base class of all address book implementations."""
 
     def __init__(self, name, path):
+        """
+        :param name: the name to identify the address book
+        :type name: str
+        :param path: the path to the backing structure on disk
+        :type path: str
+        """
         self.loaded = False
-        self.contact_list = []
+        self.contacts = []
         self._uids = set()
         self.name = name
         self.path = os.path.expanduser(path)
         if not os.path.isdir(self.path):
-            raise FileNotFoundError(
-                "[Errno 2] The path %s to the address book %s does not exist."
-                % (self.path, self))
+            raise FileNotFoundError("[Errno 2] The path {} to the address book"
+                                    " {} does not exist.".format(path, name))
 
     def __str__(self):
         return self.name
 
     def __eq__(self, other):
-        return isinstance(other, AddressBook) and self.name == other.name
+        return isinstance(other, type(self)) and self.name == other.name
 
     def __ne__(self, other):
         return not self == other
+
+    def _search_all(self, query):
+        """Search in all fields for contacts matching query.
+
+        :param query: the query to search for
+        :type query: str
+        :yields: all found contacts
+        :rtype: generator(carddav_object.CarddavObject)
+
+        """
+        regexp = re.compile(query, re.IGNORECASE | re.DOTALL)
+        for contact in self.contacts:
+            # search in all contact fields
+            contact_details = contact.print_vcard()
+            # find phone numbers with special chars like /
+            clean_contact_details = re.sub("[^a-zA-Z0-9\n]", "",
+                                           contact_details)
+            if regexp.search(contact_details) is not None or regexp.search(
+                    clean_contact_details) is not None:
+                yield contact
+
+    def _search_names(self, query):
+        """Search in the name filed for contacts matching query.
+
+        :param query: the query to search for
+        :type query: str
+        :yields: all found contacts
+        :rtype: generator(carddav_object.CarddavObject)
+
+        """
+        regexp = re.compile(query, re.IGNORECASE | re.DOTALL)
+        for contact in self.contacts:
+            # only search in contact name
+            if regexp.search(contact.get_full_name()) is not None:
+                yield contact
+
+    def _search_uid(self, query):
+        """Search for contacts with a matching uid.
+
+        :param query: the query to search for
+        :type query: str
+        :yields: all found contacts
+        :rtype: generator(carddav_object.CarddavObject)
+
+        """
+        contacts = []
+        # Search for contacts with uid == query.
+        for contact in self.contacts:
+            if contact.get_uid() == query:
+                yield contact
+        # If that fails, search for contacts where uid starts with query.
+        if not contacts:
+            for contact in self.contacts:
+                if contact.get_uid().startswith(query):
+                    yield contact
+
+    def search(self, query, method="all"):
+        """Search this address book for contacts matching the query.  The
+        method can be one of "all", "name" and "uid".
+
+        :param query: the query to search for
+        :type query: str
+        :param method: the type of fileds to use when seaching
+        :type method: str
+        :returns: all found contacts
+        :rtype: list(carddav_object.CarddavObject)
+
+        """
+        if not self.loaded:
+            self.load(query)
+        if method == "all":
+            search_function = self._search_all
+        elif method == "name":
+            search_function = self._search_names
+        elif method == "uid":
+            search_function = self._search_uid
+        else:
+            raise ValueError('Only the search methods "all", "name" and "uid" '
+                             'are supported.')
+        return list(search_function(query))
+
+    @abc.abstractmethod
+    def load(self, query=None, private_objects=tuple(), localize_dates=True):
+        """Load the vCards from the backing store.  If a query is given loading
+        is limited to entries which match the query.  If the query is None all
+        entries will be loaded.
+
+        :param query: the query to limit loading to matching entries
+        :type query: str
+        :param private_objects: the names of private vCard extension fields to
+            load
+        :type private_objects: iterable(str)
+        :param localize_dates: TODO
+        :type localize_dates: bool
+        :returns: the number of loaded contacts and the number of errors
+        :rtype: (int, int)
+
+        """
+        pass
+
+
+class VdirAddressBook(AddressBook):
+
+    """Holds the contacts inside one address book folder.  On disk they are
+    stored in vcard files."""
 
     def _find_vcard_files(self, search=None):
         """Find all vcard files inside this address book.  If a search string
@@ -62,7 +172,7 @@ class AddressBook:
 
         """
         duplicates = set()
-        for contact in self.contact_list:
+        for contact in self.contacts:
             uid = contact.get_uid()
             if uid in self._uids:
                 duplicates.add(uid)
@@ -70,28 +180,31 @@ class AddressBook:
                 self._uids.add(uid)
         return duplicates
 
-    def load_all_vcards(self, private_objects=tuple(), localize_dates=True,
-            search=None):
+    def load(self, query=None, private_objects=tuple(), localize_dates=True):
         """Load all vcard files in this address book from disk.  If a search
         string is given only files which contents match that will be loaded.
 
+        :param query: a regular expression to limit the results
+        :type query: str
         :param private_objects: the names of private vcard extension fields to
             load
         :type private_objects: list(str) or tuple(str)
-        :param search: a regular expression to limit the results
-        :type search: str
+        :param localize_dates: TODO
+        :type localize_dates: bool
         :returns: the number of successfully loaded cards and the number of
             errors
         :rtype: int, int
 
         """
         if self.loaded:
-            return len(self.contact_list), 0
+            return len(self.contacts), 0
+        contacts = 0
         errors = 0
-        for filename in self._find_vcard_files(search=search):
+        for filename in self._find_vcard_files(search=query):
+            contacts += 1
             try:
-                card = CarddavObject.from_file(self, filename,
-                        private_objects, localize_dates)
+                card = CarddavObject.from_file(self, filename, private_objects,
+                                               localize_dates)
             except IOError as err:
                 logging.debug("Error: Could not open file %s\n%s", filename,
                               err)
@@ -101,94 +214,11 @@ class AddressBook:
                               err)
                 errors += 1
             else:
-                self.contact_list.append(card)
+                self.contacts.append(card)
         duplicates = self._check_uids()
         if duplicates:
             logging.warning(
-                "There are duplicate UIDs in the address book %s: %s", self,
-                duplicates)
+                "There are duplicate UIDs in the address book %s: %s",
+                self.name, duplicates)
         self.loaded = True
-        return len(self.contact_list), errors
-
-    def _search_all(self, query):
-        """Search in all fields for contacts matching query.
-
-        :param query: the query to search for
-        :type query: str
-        :yields: all found contacts
-        :rtype: generator(carddav_object.CarddavObject)
-
-        """
-        regexp = re.compile(query, re.IGNORECASE | re.DOTALL)
-        for contact in self.contact_list:
-            # search in all contact fields
-            contact_details = contact.print_vcard()
-            # find phone numbers with special chars like /
-            contact_details_without_special_chars = re.sub("[^a-zA-Z0-9\n]",
-                                                           "", contact_details)
-            if regexp.search(contact_details) is not None or regexp.search(
-                    contact_details_without_special_chars) is not None:
-                yield contact
-
-    def _search_names(self, query):
-        """Search in the name filed for contacts matching query.
-
-        :param query: the query to search for
-        :type query: str
-        :yields: all found contacts
-        :rtype: generator(carddav_object.CarddavObject)
-
-        """
-        regexp = re.compile(query, re.IGNORECASE | re.DOTALL)
-        for contact in self.contact_list:
-            # only search in contact name
-            if regexp.search(contact.get_full_name()) is not None:
-                yield contact
-
-    def _search_uid(self, query):
-        """Search for contacts with a matching uid.
-
-        :param query: the query to search for
-        :type query: str
-        :yields: all found contacts
-        :rtype: generator(carddav_object.CarddavObject)
-
-        """
-        contacts = []
-        # Search for contacts with uid == query.
-        for contact in self.contact_list:
-            if contact.get_uid() == query:
-                yield contact
-        # If that fails, search for contacts where uid starts with query.
-        if not contacts:
-            for contact in self.contact_list:
-                if contact.get_uid().startswith(query):
-                    yield contact
-
-    def search(self, query, method="all"):
-        """Search this address book for contacts matching the query.  The
-        method can be one of "all", "name" and "uid".
-
-        :param query: the query to search for
-        :type query: str
-        :param method: the type of fileds to use when seaching
-        :type method: str
-        :returns: all found contacts
-        :rtype: list(carddav_object.CarddavObject)
-
-        """
-        if method == "all" or method == "name":
-            if method == "all":
-                search_function = self._search_all
-            else:
-                search_function = self._search_names
-            # check if query is already an regexp, else escape it
-            if not (query.startswith(".*") and query.endswith(".*")):
-                query = re.escape(query)
-            return list(search_function(query))
-        elif method == "uid":
-            # always escape uids
-            return list(self._search_uid(re.escape(query)))
-        else:
-            raise ValueError('Only the search methods "all", "name" and "uid" '
-                             'are supported.')
+        return contacts, errors

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -323,12 +323,13 @@ class AddressBookCollection(AddressBook):
         for arguments in args:
             self._abooks.append(VdirAddressBook(*arguments))
 
-    def load(self, query=None, private_objects=tuple()):
+    def load(self, query=None, private_objects=tuple(), localize_dates=True,
+             skip=False):
         if self.loaded:
             return len(self.contacts), 0
         errors = 0
         for abook in self._abooks:
-            _, err = abook.load(query, private_objects)
+            _, err = abook.load(query, private_objects, localize_dates, skip)
             errors += err
         self.loaded = True
         self.contacts = [contact for contact in abook.contacts

--- a/khard/config.py
+++ b/khard/config.py
@@ -242,10 +242,15 @@ class Config:
             return None
         if not address_book.loaded:
             try:
-                # load vcard files of address book
+                # Load vcard files of the address book.
                 contacts, errors = address_book.load(
                     search_queries, self.get_supported_private_objects(),
                     self.localize_dates(), self.skip_unparsable())
+                # Check uniqueness of vcard uids and create short uid
+                # dictionary. This can be disabled with the show_uids option in
+                # the config file, if desired.
+                if self.config['contact table']['show_uids']:
+                    self.uid_dict = self.abook.get_short_uid_dict()
             except AddressBookParseError as err:
                 if not self.skip_unparsable():
                     logging.error(
@@ -253,12 +258,6 @@ class Config:
                         "parsed\nUse --debug for more information or "
                         "--skip-unparsable to proceed", err.filename, name)
                     sys.exit(2)
-
-            # Check uniqueness of vcard uids and create short uid dictionary.
-            # This can be disabled with the show_uids option in the config
-            # file, if desired.
-            if self.config['contact table']['show_uids']:
-                self.uid_dict = self.abook.get_short_uid_dict()
         return address_book
 
     def has_uids(self):

--- a/khard/config.py
+++ b/khard/config.py
@@ -246,17 +246,17 @@ class Config:
                 contacts, errors = address_book.load(
                     search_queries, self.get_supported_private_objects(),
                     self.localize_dates(), self.skip_unparsable())
-            except AddressBookParseError:
+            except AddressBookParseError as err:
                 if not self.skip_unparsable():
                     logging.error(
-                        "%d of %d vcard files of address book %s could not be "
+                        "The vcard file %s of address book %s could not be "
                         "parsed\nUse --debug for more information or "
-                        "--skip-unparsable to proceed", errors, contacts, name)
+                        "--skip-unparsable to proceed", err.filename, name)
                     sys.exit(2)
 
             # Check uniqueness of vcard uids and create short uid dictionary.
-            # This can be disabled with the show_uids option in the config file,
-            # if desired.
+            # This can be disabled with the show_uids option in the config
+            # file, if desired.
             if self.config['contact table']['show_uids']:
                 self.uid_dict = self.abook.get_short_uid_dict()
         return address_book

--- a/khard/config.py
+++ b/khard/config.py
@@ -13,7 +13,7 @@ import sys
 import configobj
 
 from .actions import Actions
-from .address_book import AddressBook
+from .address_book import VdirAddressBook
 from . import helpers
 
 
@@ -185,7 +185,7 @@ class Config:
         for name in self.config['addressbooks'].keys():
             # create address book object
             try:
-                address_book = AddressBook(
+                address_book = VdirAddressBook(
                     name, self.config['addressbooks'][name]['path'])
             except KeyError:
                 exit("Missing path to the \"%s\" address book." % name)
@@ -227,7 +227,7 @@ class Config:
         address books already contain their contact objects
         if you must be sure, get every address book individually with the
         get_address_book() function below
-        :rtype: list(AddressBook)
+        :rtype: list(address_book.AddressBook)
         """
         return self.address_book_list
 
@@ -235,7 +235,7 @@ class Config:
         """
         return address book object or None, if the address book with the
         given name does not exist
-        :rtype: AddressBook
+        :rtype: address_book.AddressBook
         """
         if not self.search_in_source_files():
             search_queries = None
@@ -243,9 +243,9 @@ class Config:
             if name == address_book.name:
                 if not address_book.loaded:
                     # load vcard files of address book
-                    contacts, errors = address_book.load_all_vcards(
-                        self.get_supported_private_objects(),
-                        self.localize_dates(), search_queries)
+                    contacts, errors = address_book.load(
+                        search_queries, self.get_supported_private_objects(),
+                        self.localize_dates())
 
                     # check if one or more contacts could not be parsed
                     if errors > 0:
@@ -266,7 +266,7 @@ class Config:
                     # in the config file, if desired.
                     if self.config['contact table']['show_uids']:
                         # check, if multiple contacts have the same uid
-                        for contact in address_book.contact_list:
+                        for contact in address_book.contacts:
                             uid = contact.get_uid()
                             if uid:
                                 if uid not in self.original_uid_dict:

--- a/khard/config.py
+++ b/khard/config.py
@@ -13,7 +13,7 @@ import sys
 import configobj
 
 from .actions import Actions
-from .address_book import VdirAddressBook
+from .address_book import AddressBookCollection
 from . import helpers
 
 
@@ -182,18 +182,16 @@ class Config:
             exit('Missing main section "[addressbooks]".')
         if not self.config['addressbooks'].keys():
             exit("No address book entries available.")
-        for name in self.config['addressbooks'].keys():
-            # create address book object
-            try:
-                address_book = VdirAddressBook(
-                    name, self.config['addressbooks'][name]['path'])
-            except KeyError:
-                exit("Missing path to the \"%s\" address book." % name)
-            except IOError as err:
-                exit(str(err))
-            else:
-                # add address book to list
-                self.address_book_list.append(address_book)
+        section = self.config['addressbooks']
+        try:
+            self.abook = AddressBookCollection(
+                "tmp", *[(name, section[name]['path']) for name in section])
+        except KeyError as err:
+            exit('Missing path to the "{}" address book.'.format(err.args[0]))
+        except IOError as err:
+            exit(str(err))
+        self.address_book_list = [self.abook.get_abook(name)
+                                  for name in section]
 
     @staticmethod
     def _convert_boolean_config_value(config, name, default=True):

--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -92,26 +92,6 @@ def get_random_uid():
                     for _ in range(36)])
 
 
-def compare_uids(uid1, uid2):
-    """Calculate the minimum length of initial substrings of uid1 and uid2 for
-    them to be different.
-
-    :param uid1: first uid to compare
-    :type uid1: str
-    :param uid2: second uid to compare
-    :type uid2: str
-    :returns: the length of the shortes unequal inital substrings
-    :rtype: int
-    """
-    sum = 0
-    for c1, c2 in zip(uid1, uid2):
-        if c1 == c2:
-            sum += 1
-        else:
-            break
-    return sum
-
-
 def file_modification_date(filename):
     t = os.path.getmtime(filename)
     return datetime.fromtimestamp(t)
@@ -251,28 +231,28 @@ def get_new_contact_template(supported_private_objects=[]):
         # every entry may contain a string or a list of strings
         # format:
         #   First name : name1
-        #   Additional : 
+        #   Additional :
         #       - name2
         #       - name3
         #   Last name  : name4
-        Prefix     : 
-        First name : 
-        Additional : 
-        Last name  : 
-        Suffix     : 
+        Prefix     :
+        First name :
+        Additional :
+        Last name  :
+        Suffix     :
 
         # nickname
         # may contain a string or a list of strings
-        Nickname : 
+        Nickname :
 
         # important dates
         # Formats:
         #   vcard 3.0 and 4.0: yyyy-mm-dd or yyyy-mm-ddTHH:MM:SS
         #   vcard 4.0 only: --mm-dd or text= string value
         # anniversary
-        Anniversary : 
+        Anniversary :
         # birthday
-        Birthday : 
+        Birthday :
 
         # organisation
         # format:
@@ -286,17 +266,17 @@ def get_new_contact_template(supported_private_objects=[]):
         #       -
         #           - company
         #           - unit
-        Organisation : 
+        Organisation :
 
         # organisation title and role
         # every entry may contain a string or a list of strings
         #
         # title at organisation
         # example usage: research scientist
-        Title : 
+        Title :
         # role at organisation
         # example usage: project leader
-        Role  : 
+        Role  :
 
         # phone numbers
         # format:
@@ -314,8 +294,8 @@ def get_new_contact_template(supported_private_objects=[]):
         #   Alternatively you may use a single custom label (only letters).
         #   But beware, that not all address book clients will support custom labels.
         Phone :
-            cell : 
-            home : 
+            cell :
+            home :
 
         # email addresses
         # format like phone numbers above
@@ -324,8 +304,8 @@ def get_new_contact_template(supported_private_objects=[]):
         #   vcard 4.0: At least one of home, internet, pref, work
         #   Alternatively you may use a single custom label (only letters).
         Email :
-            home : 
-            work : 
+            home :
+            work :
 
         # post addresses
         # allowed types:
@@ -334,13 +314,13 @@ def get_new_contact_template(supported_private_objects=[]):
         #   Alternatively you may use a single custom label (only letters).
         Address :
             home :
-                Box      : 
-                Extended : 
-                Street   : 
-                Code     : 
-                City     : 
-                Region   : 
-                Country  : 
+                Box      :
+                Extended :
+                Street   :
+                Code     :
+                City     :
+                Region   :
+                Country  :
 
         # categories or tags
         # format:
@@ -349,11 +329,11 @@ def get_new_contact_template(supported_private_objects=[]):
         #   Categories :
         #       - category1
         #       - category2
-        Categories : 
+        Categories :
 
         # web pages
         # may contain a string or a list of strings
-        Webpage : 
+        Webpage :
 
         # private objects
         # define your own private objects in the vcard section of your khard config file
@@ -371,6 +351,6 @@ def get_new_contact_template(supported_private_objects=[]):
         #   Note : |
         #       line one
         #       line two
-        Note : 
+        Note :
         """ % '\n'.join(formatted_private_objects))
 

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -1451,9 +1451,18 @@ def parse_args(argv):
         remainder.insert(0, config.default_action)
         logging.debug("updated remainder={}".format(remainder))
 
+    # Save the last option that needs to be carried from the first parser run
+    # to the second.
+    skip = args.skip_unparsable
+
     # Parse the remainder of the command line.  All options from the previous
     # run have already been processed and are not needed any more.
     args = parser.parse_args(remainder)
+
+    # Restore settings that are left from the first parser run.
+    args.skip_unparsable = skip
+
+    # Finish up with a debug report and return the result.
     logging.debug("second args={}".format(args))
     return args
 

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -432,7 +432,7 @@ def choose_vcard_from_list(header_string, vcard_list):
 def get_contact_list_by_user_selection(address_books, search, strict_search):
     """returns a list of CarddavObject objects
     :param address_books: list of selected address books
-    :type address_books: list(AddressBook)
+    :type address_books: list(address_book.AddressBook)
     :param search: filter contact list
     :type search: str
     :param strict_search: if True, search only in full name field

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -20,3 +20,27 @@ class AbstractAddressBookSearch(unittest.TestCase):
             with self.assertRaises(ValueError):
                 abook = _AddressBook('test', "/this-doesn't-exist")
                 abook.search('query', method='invalid_method')
+
+
+class AddressBookCompareUids(unittest.TestCase):
+
+    def test_different_strings(self):
+        uid1 = 'abc'
+        uid2 = 'xyz'
+        expected = 0
+        actual = address_book.AddressBook._compare_uids(uid1, uid2)
+        self.assertEqual(actual, expected)
+
+    def test_two_simple_strings(self):
+        uid1 = 'abcdef'
+        uid2 = 'abcxyz'
+        expected = 3
+        actual = address_book.AddressBook._compare_uids(uid1, uid2)
+        self.assertEqual(actual, expected)
+
+    def test_no_error_on_equal_strings(self):
+        uid = 'abcdefghij'
+        expected = len(uid)
+        actual = address_book.AddressBook._compare_uids(uid, uid)
+        self.assertEqual(actual, expected)
+

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -16,10 +16,9 @@ class AbstractAddressBookSearch(unittest.TestCase):
     """Tests for khard.address_book.AddressBook.search()"""
 
     def test_invalide_method_failes(self):
-        with mock.patch('os.path.isdir', lambda _: True):
-            with self.assertRaises(ValueError):
-                abook = _AddressBook('test', "/this-doesn't-exist")
-                abook.search('query', method='invalid_method')
+        with self.assertRaises(ValueError):
+            abook = _AddressBook('test')
+            abook.search('query', method='invalid_method')
 
 
 class AddressBookCompareUids(unittest.TestCase):

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -1,0 +1,22 @@
+"""Tests for the address book classes."""
+
+import unittest
+from unittest import mock
+
+from khard import address_book
+
+
+class _AddressBook(address_book.AddressBook):
+    """Class for testing the abstract AddressBook base class."""
+    def load(self, query=None, private_objects=tuple(), localize_dates=True):
+        pass
+
+
+class AbstractAddressBookSearch(unittest.TestCase):
+    """Tests for khard.address_book.AddressBook.search()"""
+
+    def test_invalide_method_failes(self):
+        with mock.patch('os.path.isdir', lambda _: True):
+            with self.assertRaises(ValueError):
+                abook = _AddressBook('test', "/this-doesn't-exist")
+                abook.search('query', method='invalid_method')

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -6,29 +6,6 @@ import unittest
 from khard import helpers
 
 
-class CompareUids(unittest.TestCase):
-
-    def test_different_strings(self):
-        uid1 = 'abc'
-        uid2 = 'xyz'
-        expected = 0
-        actual = helpers.compare_uids(uid1, uid2)
-        self.assertEqual(actual, expected)
-
-    def test_two_simple_strings(self):
-        uid1 = 'abcdef'
-        uid2 = 'abcxyz'
-        expected = 3
-        actual = helpers.compare_uids(uid1, uid2)
-        self.assertEqual(actual, expected)
-
-    def test_no_error_on_equal_strings(self):
-        uid = 'abcdefghij'
-        expected = len(uid)
-        actual = helpers.compare_uids(uid, uid)
-        self.assertEqual(actual, expected)
-
-
 class ListToString(unittest.TestCase):
 
     def test_empty_list_returns_empty_string(self):


### PR DESCRIPTION
This PR moves as much responsibility about managing collections of vcards to the address book (as I believe it is not really the responsibility of the config class to manage vcards).

Also the AddressBook class is split up so it can be extended more easily.  Currently an abstract base class, one class to load from a directory of vcard files and one class to collect many such folders into one abstract address book are implemented.  The AddressBookCollection class takes over many of the responsibilities of the config class about managing vcards from different address books.  One idea to extend this could be that we could use a cache to reduce the time needed for parsing all the vcards as it looks like this is the main bottle neck for khard's performance at the moment.  But that is a discussion for another PR/issue.

I can notice a very small performance improvement with this PR.  I use this zsh code to test it:
```zsh
export PYTHONPATH=.
upsteam=develop
count=10
head=$(git rev-parse --abbrev-ref HEAD)
time (for i in {0..$count}; do ./khard-runner.py ls &>/dev/null; done )
git checkout $upstream
time (for i in {0..$count}; do ./khard-runner.py ls &>/dev/null; done )
git checkout $head
```
I assume that this improvement is due to my reimplementation of the `get_short_uid_dict()` method which I did clean up and free of some needless recomputations of the same constant values.