### PR TITLE
Add new command "filename"

### DIFF
--- a/khard/actions.py
+++ b/khard/actions.py
@@ -14,6 +14,7 @@ class Actions:
         "details":      ["show"],
         "email":        [],
         "export":       [],
+        "filename":     ["file"],
         "list":         ["ls"],
         "merge":        [],
         "modify":       ["edit", "ed"],

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -1412,6 +1412,13 @@ def parse_args(argv):
         aliases=Actions.get_aliases("addressbooks"),
         description="list addressbooks",
         help="list addressbooks")
+    subparsers.add_parser(
+        "filename",
+        aliases=Actions.get_aliases("filename"),
+        parents=[default_addressbook_parser, default_search_parser,
+                 sort_parser],
+        description="list filenames of all matching contacts",
+        help="list filenames of all matching contacts")
 
     # Replace the print_help method of the first parser with the print_help
     # method of the main parser.  This makes it possible to have the first
@@ -1692,3 +1699,5 @@ def main(argv=sys.argv[1:]):
             args.action, vcard_list, args.target_addressbook)
     elif args.action == "addressbooks":
         print('\n'.join(str(book) for book in config.get_all_address_books()))
+    elif args.action == "filename":
+        print('\n'.join(contact.filename for contact in vcard_list))

--- a/misc/zsh/_khard
+++ b/misc/zsh/_khard
@@ -55,6 +55,7 @@ case $state in
       {details,show}:'show details for a contact'
       email:'list email addresses'
       export:'export a contact'
+      {filename,file}':list internal file names'
       {list,ls}:'list all (selected) contacts'
       merge:'merge two contacts'
       {modify,edit,ed}:'edit a contact'
@@ -126,7 +127,7 @@ case $state in
     case $words[1] in
       addressbooks|abooks)
         options+=();;
-      details|show|source|src)
+      list|ls|details|show|source|src|remove|delete|del|rm|filename|file)
         options+=(
           $default_addressbook_options $default_search_options $sort_options
         );;


### PR DESCRIPTION
I found this old commit lying around. It might fit #139, @DamienCassou?

The command will print the full file names of all matching contacts.  The file
names are the original vcard files in the address book on disk, not temporary
files.  The command can be used for scripting, when khard should be used
together with some other tool.