### PR TITLE
Turn contact list in AddressBook into a dict

### DIFF
--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -239,14 +239,15 @@ class VdirAddressBook(AddressBook):
         :rtype: generator
 
         """
-        for filename in glob.glob(os.path.join(self.path, "*.vcf")):
-            if search:
+        files = glob.glob(os.path.join(self.path, "*.vcf"))
+        if search:
+            for filename in files:
                 with open(filename, "r") as filehandle:
                     if re.search(search, filehandle.read(),
                                  re.IGNORECASE | re.DOTALL):
                         yield filename
-            else:
-                yield filename
+        else:
+            yield from files
 
     def load(self, query=None):
         """Load all vcard files in this address book from disk.  If a search

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -317,8 +317,6 @@ class AddressBookCollection(AddressBook):
         for abook in self._abooks:
             _, err = abook.load(query, private_objects, localize_dates, skip)
             errors += err
-        self.loaded = True
-        for abook in self._abooks:
             for uid in abook.contacts:
                 if uid in self.contacts:
                     logging.warning(
@@ -327,6 +325,7 @@ class AddressBookCollection(AddressBook):
                         "UID: %s", abook.contacts[uid], abook, uid)
                 else:
                     self.contacts[uid] = abook.contacts[uid]
+        self.loaded = True
         return len(self.contacts), errors
 
     def get_abook(self, name):

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -175,8 +175,11 @@ class AddressBook(metaclass=abc.ABCMeta):
         if self._short_uids is None:
             if not self._loaded:
                 self.load(query)
-            if not self.contacts or len(self.contacts) == 1:
-                self._short_uids = self.contacts
+            if not self.contacts:
+                self._short_uids = {}
+            elif len(self.contacts) == 1:
+                self._short_uids = {uid[0:1]: contact
+                                    for uid, contact in self.contacts.items()}
             else:
                 self._short_uids = {}
                 sorted_uids = sorted(self.contacts)

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -23,7 +23,6 @@ class AddressBookParseError(Exception):
 
 
 class AddressBook(metaclass=abc.ABCMeta):
-
     """The base class of all address book implementations."""
 
     def __init__(self, name, private_objects=tuple(), localize_dates=True,
@@ -69,8 +68,8 @@ class AddressBook(metaclass=abc.ABCMeta):
         :rtype: int
         """
         sum = 0
-        for c1, c2 in zip(uid1, uid2):
-            if c1 == c2:
+        for char1, char2 in zip(uid1, uid2):
+            if char1 == char2:
                 sum += 1
             else:
                 break
@@ -135,8 +134,10 @@ class AddressBook(metaclass=abc.ABCMeta):
                     yield self.contacts[uid]
 
     def search(self, query, method="all"):
-        """Search this address book for contacts matching the query.  The
-        method can be one of "all", "name" and "uid".
+        """Search this address book for contacts matching the query.
+
+        The method can be one of "all", "name" and "uid".  The backend for this
+        address book migth be load()ed if needed.
 
         :param query: the query to search for
         :type query: str
@@ -197,9 +198,10 @@ class AddressBook(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def load(self, query=None):
-        """Load the vCards from the backing store.  If a query is given loading
-        is limited to entries which match the query.  If the query is None all
-        entries will be loaded.
+        """Load the vCards from the backing store.
+
+        If a query is given loading is limited to entries which match the
+        query.  If the query is None all entries will be loaded.
 
         :param query: the query to limit loading to matching entries
         :type query: str
@@ -211,9 +213,11 @@ class AddressBook(metaclass=abc.ABCMeta):
 
 
 class VdirAddressBook(AddressBook):
+    """An AddressBook implementation based on a vdir.
 
-    """Holds the contacts inside one address book folder.  On disk they are
-    stored in vcard files."""
+    This address book can load contacts from vcard files that reside in one
+    direcotry on disk.
+    """
 
     def __init__(self, name, path, **kwargs):
         """
@@ -230,8 +234,10 @@ class VdirAddressBook(AddressBook):
         super().__init__(name, **kwargs)
 
     def _find_vcard_files(self, search=None):
-        """Find all vcard files inside this address book.  If a search string
-        is given only files which contents match that will be returned.
+        """Find all vcard files inside this address book.
+
+        If a search string is given only files which contents match that will
+        be returned.
 
         :param search: a regular expression to limit the results
         :type search: str
@@ -250,8 +256,10 @@ class VdirAddressBook(AddressBook):
             yield from files
 
     def load(self, query=None):
-        """Load all vcard files in this address book from disk.  If a search
-        string is given only files which contents match that will be loaded.
+        """Load all vcard files in this address book from disk.
+
+        If a search string is given only files which contents match that will
+        be loaded.
 
         :param query: a regular expression to limit the results
         :type query: str
@@ -304,10 +312,13 @@ class VdirAddressBook(AddressBook):
 
 
 class AddressBookCollection(AddressBook):
+    """A collection of several address books.
 
-    """A collection of several address books.  This represents the a temporary
-    merege of the contact collections provided by the underlying adress
-    books."""
+    This represents a temporary merege of the contact collections provided by
+    the underlying adress books.  On load all contacts from all subadressbooks
+    are copied into a dict in this address book.  This allow this class to use
+    all other methods from the parent AddressBook class.
+    """
 
     def __init__(self, name, *args, **kwargs):
         """

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -53,7 +53,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         :type uid1: str
         :param uid2: second uid to compare
         :type uid2: str
-        :returns: the length of the shortes unequal inital substrings
+        :returns: the length of the shortes unequal initial substrings
         :rtype: int
         """
         sum = 0
@@ -147,16 +147,29 @@ class AddressBook(metaclass=abc.ABCMeta):
                              'are supported.')
         return list(search_function(query))
 
-    def get_short_uid_dict(self):
+    def get_short_uid_dict(self, query=None, private_objects=tuple(),
+                           localize_dates=True, skip=False):
         """Create a dictionary of shortend UIDs for all contacts.
 
+        All arguments are only used if the address book is not yet initialized
+        and will just be handed to self.load().
+
+        :param query: see self.load()
+        :type query: str
+        :param private_objects: see self.load()
+            load
+        :type private_objects: iterable(str)
+        :param localize_dates: see self.load()
+        :type localize_dates: bool
+        :param skip: see self.load()
+        :type skip: bool
         :returns: the contacts mapped by the shortes unique prefix of their UID
         :rtype: dict(str: CarddavObject)
 
         """
         if self._short_uids is None:
             if not self.loaded:
-                self.load()
+                self.load(query, private_objects, localize_dates, skip)
             if not self.contacts or len(self.contacts) == 1:
                 self._short_uids = self.contacts
             else:
@@ -179,7 +192,8 @@ class AddressBook(metaclass=abc.ABCMeta):
         return self._short_uids
 
     @abc.abstractmethod
-    def load(self, query=None, private_objects=tuple(), localize_dates=True):
+    def load(self, query=None, private_objects=tuple(), localize_dates=True,
+             skip=False):
         """Load the vCards from the backing store.  If a query is given loading
         is limited to entries which match the query.  If the query is None all
         entries will be loaded.
@@ -191,6 +205,8 @@ class AddressBook(metaclass=abc.ABCMeta):
         :type private_objects: iterable(str)
         :param localize_dates: TODO
         :type localize_dates: bool
+        :param skip: skip unparsable vCard files
+        :type skip: bool
         :returns: the number of loaded contacts and the number of errors
         :rtype: (int, int)
 

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -111,17 +111,16 @@ class AddressBook(metaclass=abc.ABCMeta):
         :rtype: generator(carddav_object.CarddavObject)
 
         """
-        found = False
-        # Search for contacts with uid == query.
-        for contact in self.contacts.values():
-            if contact.get_uid() == query:
-                found = True
-                yield contact
-        # If that fails, search for contacts where uid starts with query.
-        if not found:
-            for contact in self.contacts.values():
-                if contact.get_uid().startswith(query):
-                    yield contact
+        try:
+            # First we treat the argument as a full UID and try to match it
+            # exactly.
+            yield self.contacts[query]
+        except KeyError:
+            # If that failed we look for all contacts whos UID start with the
+            # given query.
+            for uid in self.contacts:
+                if uid.startswith(query):
+                    yield self.contacts[uid]
 
     def search(self, query, method="all"):
         """Search this address book for contacts matching the query.  The

--- a/khard/config.py
+++ b/khard/config.py
@@ -35,7 +35,7 @@ class Config:
 
     def __init__(self, config_file=""):
         self.config = None
-        self.address_book_list = []
+        self.abooks = []
         self.uid_dict = {}
 
         # set locale
@@ -186,8 +186,7 @@ class Config:
             exit('Missing path to the "{}" address book.'.format(err.args[0]))
         except IOError as err:
             exit(str(err))
-        self.address_book_list = [self.abook.get_abook(name)
-                                  for name in section]
+        self.abooks = [self.abook.get_abook(name) for name in section]
 
     @staticmethod
     def _convert_boolean_config_value(config, name, default=True):
@@ -216,17 +215,6 @@ class Config:
         else:
             raise ValueError("Error in config file\nInvalid value for %s "
                              "parameter\nPossible values: yes, no" % name)
-
-    def get_all_address_books(self):
-        """
-        return a list of all address books from config file
-        But due to performance optimizations its not guaranteed, that the
-        address books already contain their contact objects
-        if you must be sure, get every address book individually with the
-        get_address_book() function below
-        :rtype: list(address_book.AddressBook)
-        """
-        return self.address_book_list
 
     def get_address_book(self, name, search_queries=None):
         """

--- a/khard/config.py
+++ b/khard/config.py
@@ -248,7 +248,9 @@ class Config:
                 # dictionary. This can be disabled with the show_uids option in
                 # the config file, if desired.
                 if self.config['contact table']['show_uids']:
-                    self.uid_dict = self.abook.get_short_uid_dict()
+                    self.uid_dict = self.abook.get_short_uid_dict(
+                        search_queries, self.get_supported_private_objects(),
+                        self.localize_dates(), self.skip_unparsable())
             except AddressBookParseError as err:
                 if not self.skip_unparsable():
                     logging.error(

--- a/khard/config.py
+++ b/khard/config.py
@@ -179,7 +179,10 @@ class Config:
         section = self.config['addressbooks']
         try:
             self.abook = AddressBookCollection(
-                "tmp", *[(name, section[name]['path']) for name in section])
+                "tmp", *[(name, section[name]['path']) for name in section],
+                private_objects=self.get_supported_private_objects(),
+                localize_dates=self.localize_dates(),
+                skip=self.skip_unparsable())
         except KeyError as err:
             exit('Missing path to the "{}" address book.'.format(err.args[0]))
         except IOError as err:
@@ -241,16 +244,13 @@ class Config:
         if not address_book.loaded:
             try:
                 # Load vcard files of the address book.
-                contacts, errors = address_book.load(
-                    search_queries, self.get_supported_private_objects(),
-                    self.localize_dates(), self.skip_unparsable())
+                contacts, errors = address_book.load(search_queries)
                 # Check uniqueness of vcard uids and create short uid
                 # dictionary. This can be disabled with the show_uids option in
                 # the config file, if desired.
                 if self.config['contact table']['show_uids']:
                     self.uid_dict = self.abook.get_short_uid_dict(
-                        search_queries, self.get_supported_private_objects(),
-                        self.localize_dates(), self.skip_unparsable())
+                        search_queries)
             except AddressBookParseError as err:
                 if not self.skip_unparsable():
                     logging.error(

--- a/khard/config.py
+++ b/khard/config.py
@@ -2,7 +2,6 @@
 
 from distutils.spawn import find_executable
 import locale
-import logging
 import os
 import re
 import sys
@@ -10,7 +9,7 @@ import sys
 import configobj
 
 from .actions import Actions
-from .address_book import AddressBookCollection, AddressBookParseError
+from .address_book import AddressBookCollection
 
 
 def exit(message, prefix="Error in config file\n"):
@@ -241,23 +240,11 @@ class Config:
         if not address_book:
             # Return None if no address book did match the given name.
             return None
-        if not address_book.loaded:
-            try:
-                # Load vcard files of the address book.
-                contacts, errors = address_book.load(search_queries)
-                # Check uniqueness of vcard uids and create short uid
-                # dictionary. This can be disabled with the show_uids option in
-                # the config file, if desired.
-                if self.config['contact table']['show_uids']:
-                    self.uid_dict = self.abook.get_short_uid_dict(
-                        search_queries)
-            except AddressBookParseError as err:
-                if not self.skip_unparsable():
-                    logging.error(
-                        "The vcard file %s of address book %s could not be "
-                        "parsed\nUse --debug for more information or "
-                        "--skip-unparsable to proceed", err.filename, name)
-                    sys.exit(2)
+        # Check uniqueness of vcard uids and create short uid
+        # dictionary. This can be disabled with the show_uids option in
+        # the config file, if desired.
+        if self.config['contact table']['show_uids']:
+            self.uid_dict = self.abook.get_short_uid_dict(search_queries)
         return address_book
 
     def has_uids(self):

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -547,14 +547,14 @@ def load_address_books(names, config, search_queries=None):
         address_book = config.get_address_book(name, search_queries)
         if address_book is None:
             sys.exit('Error: The entered address book "{}" does not exist.\n'
-                     'Possible values are: {}'.format(name, ', '.join(
-                         str(book) for book in config.get_all_address_books())))
+                     'Possible values are: {}'.format(
+                         name, ', '.join(str(book) for book in config.abooks)))
         else:
             result.append(address_book)
     # In case names were empty and the for loop did not run.
     if not result and not names:
         # load contacts of all address books
-        for address_book in config.get_all_address_books():
+        for address_book in config.abooks:
             result.append(config.get_address_book(address_book.name,
                                                   search_queries))
     logging.debug("addressbooks: %s", result)
@@ -751,8 +751,7 @@ def add_email_subcommand(input_from_stdin_or_file, selected_address_books):
                 break
         # ask for address book, in which to create the new contact
         selected_address_book = choose_address_book_from_list(
-            "Select address book for new contact",
-            config.get_all_address_books())
+            "Select address book for new contact", config.abooks)
         if selected_address_book is None:
             print("Error: address book list is empty")
             sys.exit(1)
@@ -1024,14 +1023,8 @@ def list_subcommand(vcard_list, parsable):
             else:
                 name = vcard.get_last_name_first_name()
             contact_line_list.append(
-                    '\t'.join(
-                        [
-                            config.get_shortened_uid(vcard.get_uid()),
-                            name,
-                            vcard.address_book.name
-                            ]
-                        )
-                    )
+                '\t'.join([config.get_shortened_uid(vcard.get_uid()), name,
+                           vcard.address_book.name]))
         print('\n'.join(contact_line_list))
     else:
         list_contacts(vcard_list)
@@ -1647,7 +1640,7 @@ def main(argv=sys.argv[1:]):
     # options and can directly be run.  That is much faster than checking all
     # options first and getting default values.
     if args.action == "addressbooks":
-        print('\n'.join(str(book) for book in config.get_all_address_books()))
+        print('\n'.join(str(book) for book in config.abooks))
         return
 
     merge_args_into_config(args, config)

--- a/test/fixture/foo.abook/minimal3.vcf
+++ b/test/fixture/foo.abook/minimal3.vcf
@@ -1,0 +1,5 @@
+BEGIN:VCARD
+VERSION:4.0
+FN:third contact
+UID:testuid2
+END:VCARD

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -109,3 +109,17 @@ class VcardAdressBookLoad(unittest.TestCase):
             abook.load()
         self.assertEqual(cm.output, ['WARNING:root:1 of 1 vCard files of '
                                      'address book test could not be parsed.'])
+
+
+class AddressBookGetShortUidDict(unittest.TestCase):
+
+    @unittest.expectedFailure
+    def test_uniqe_uid_also_reslts_in_shortend_uid_in_short_uid_dict(self):
+        contacts = {'uid123': None}
+        abook = _AddressBook('test')
+        abook.contacts = contacts
+        abook._loaded = True
+        short_uids = abook.get_short_uid_dict()
+        self.assertEqual(len(short_uids), 1)
+        short_uid, contact = short_uids.popitem()
+        self.assertEqual(short_uid, 'u')

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -42,7 +42,7 @@ class AbstractAddressBookSearch(unittest.TestCase):
         abook = _AddressBook('test')
         load_mock = mock.Mock()
         abook.load = load_mock
-        abook.loaded = True
+        abook._loaded = True
         abook.search('foo')
         load_mock.assert_not_called()
 
@@ -99,7 +99,7 @@ class VcardAdressBookLoad(unittest.TestCase):
     def test_loading_unparsable_vcard_fails(self):
         abook = address_book.VdirAddressBook('test',
                                              'test/fixture/broken.abook')
-        with self.assertRaises(address_book.AddressBookParseError):
+        with self.assertRaises(SystemExit):
             abook.load()
 
     def test_unparsable_files_can_be_skipped(self):

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -113,7 +113,6 @@ class VcardAdressBookLoad(unittest.TestCase):
 
 class AddressBookGetShortUidDict(unittest.TestCase):
 
-    @unittest.expectedFailure
     def test_uniqe_uid_also_reslts_in_shortend_uid_in_short_uid_dict(self):
         contacts = {'uid123': None}
         abook = _AddressBook('test')

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -87,10 +87,9 @@ class VcardAdressBookLoad(unittest.TestCase):
         with self.assertLogs(level='WARNING') as cm:
             abook.load()
         self.assertEqual(len(abook.contacts), 2)
-        # TODO: There is also a warning about duplicate uids but that might be
-        # a bug.
-        self.assertIn('WARNING:root:The contact minimal contact from address '
-                      'book test has no UID', cm.output)
+        messages = ['WARNING:root:Card minimal contact from address book test '
+                    'has no UID and will not be availbale.']
+        self.assertListEqual(cm.output, messages)
 
     def test_search_in_source_files_only_loads_matching_cards(self):
         abook = address_book.VdirAddressBook('test', 'test/fixture/foo.abook')

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -16,7 +16,7 @@ def expectedFailureForVersion(major, minor):
 
 class _AddressBook(address_book.AddressBook):
     """Class for testing the abstract AddressBook base class."""
-    def load(self, query=None, private_objects=tuple(), localize_dates=True):
+    def load(self, query=None):
         pass
 
 
@@ -103,9 +103,9 @@ class VcardAdressBookLoad(unittest.TestCase):
             abook.load()
 
     def test_unparsable_files_can_be_skipped(self):
-        abook = address_book.VdirAddressBook('test',
-                                             'test/fixture/broken.abook')
+        abook = address_book.VdirAddressBook(
+            'test', 'test/fixture/broken.abook', skip=True)
         with self.assertLogs(level='WARNING') as cm:
-            abook.load(skip=True)
+            abook.load()
         self.assertEqual(cm.output, ['WARNING:root:1 of 1 vCard files of '
                                      'address book test could not be parsed.'])

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -1,5 +1,6 @@
 """Test some features of the command line interface of khard.
 
+
 This also contains some "end to end" tests.  That means some very high level
 calls to the main function and a check against the output.  These might later
 be converted to proper "unit" tests.
@@ -58,9 +59,9 @@ class ListingCommands(unittest.TestCase):
         text = [l.strip() for l in stdout.getvalue().splitlines()]
         expected = [
             "Address book: foo",
-            "Index    Name               Phone                E-Mail                    UID",
-            "1        minimal contact",
-            "2        second contact     voice: 0123456789    home: user@example.com    t"]
+            "Index    Name              Phone                E-Mail                    UID",
+            "1        second contact    voice: 0123456789    home: user@example.com    testuid1",
+            "2        third contact                                                    testuid2"]
         self.assertListEqual(text, expected)
 
     def test_simple_bdays_without_options(self):
@@ -91,8 +92,8 @@ class ListingCommands(unittest.TestCase):
         with mock_stdout() as stdout:
             khard.main(['filename'])
         text = [line.strip() for line in stdout.getvalue().splitlines()]
-        expect = ["test/fixture/foo.abook/minimal.vcf",
-                  "test/fixture/foo.abook/minimal2.vcf"]
+        expect = ["test/fixture/foo.abook/minimal2.vcf",
+                  "test/fixture/foo.abook/minimal3.vcf"]
         self.assertListEqual(text, expect)
 
     def test_simple_abooks_without_options(self):


### PR DESCRIPTION
Nearly all of the operations that where performed on the old contacts list can easily be performed on the dict as well.  The only exception is the storing of several contacts with the same UID (but such a thing arguably shouldn't happen anyways).

This results in a drastic cleanup of the code.  But I think there is more to gain here.  But I was not able to figure out how and where the shortened uids are used.  So this part is postponed until I clean up the corresponding code from the other side (khard.py and config.py).

The last commit (66fa5d1) brings some actual speed improvement in some situations (e.g. `khard ls -f lucas`).