### PR TITLE
Use AddressBookCollection and regex speedup

### DIFF
--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -327,20 +327,16 @@ class AddressBookCollection(AddressBook):
     all other methods from the parent AddressBook class.
     """
 
-    def __init__(self, name, *args, **kwargs):
+    def __init__(self, name, abooks, **kwargs):
         """
         :param name: the name to identify the address book
         :type name: str
-        :param *args: two-tuples, each holding the name and path arguments for
-            one VdirAddressBook instance
-        :type *args: tuple(str,str)
+        :param abooks: a list of address books to combine in this collection
+        :type abooks: list(AddressBook)
         :param **kwargs: further arguments for the parent constructor
-            (AddressBook) and all sub address books
         """
         super().__init__(name, **kwargs)
-        self._abooks = []
-        for name, path in args:
-            self._abooks.append(VdirAddressBook(name, path, **kwargs))
+        self._abooks = abooks
 
     def load(self, query=None):
         if self._loaded:

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -171,7 +171,6 @@ class AddressBook(metaclass=abc.ABCMeta):
         :type query: str
         :returns: the contacts mapped by the shortes unique prefix of their UID
         :rtype: dict(str: CarddavObject)
-
         """
         if self._short_uids is None:
             if not self._loaded:

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -147,6 +147,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         :rtype: list(carddav_object.CarddavObject)
 
         """
+        logging.debug('address book %s, searching with %s', self.name, query)
         if not self._loaded:
             self.load(query)
         if method == "all":

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -200,6 +200,21 @@ class AddressBook(metaclass=abc.ABCMeta):
                 self._short_uids[item1[:same1 + 1]] = self.contacts[item1]
         return self._short_uids
 
+    def get_short_uid(self, uid):
+        """Get the shortend UID for the given UID.
+
+        :param uid: the full UID to shorten
+        :type uid: str
+        :returns: the shortend uid or the empty string
+        :rtype: str
+        """
+        if uid:
+            short_uids = self.get_short_uid_dict()
+            for length_of_uid in range(len(uid), 0, -1):
+                if short_uids.get(uid[:length_of_uid]) is not None:
+                    return uid[:length_of_uid]
+        return ""
+
     @abc.abstractmethod
     def load(self, query=None):
         """Load the vCards from the backing store.

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -273,6 +273,7 @@ class VdirAddressBook(AddressBook):
         """
         if self._loaded:
             return
+        logging.debug('Loading Vdir %s with query %s', self.name, query)
         errors = 0
         for filename in self._find_vcard_files(search=query):
             try:
@@ -312,6 +313,8 @@ class VdirAddressBook(AddressBook):
             logging.warning(
                 "%d of %d vCard files of address book %s could not be parsed.",
                 errors, len(self.contacts) + errors, self)
+        logging.debug('Loded %s contacts from address book %s.',
+                      len(self.contacts), self.name)
 
 
 class AddressBookCollection(AddressBook):
@@ -341,6 +344,7 @@ class AddressBookCollection(AddressBook):
     def load(self, query=None):
         if self._loaded:
             return
+        logging.debug('Loading collection %s with query %s', self.name, query)
         for abook in self._abooks:
             abook.load(query)
             for uid in abook.contacts:
@@ -352,6 +356,8 @@ class AddressBookCollection(AddressBook):
                 else:
                     self.contacts[uid] = abook.contacts[uid]
         self._loaded = True
+        logging.debug('Loded %s contacts from address book %s.',
+                      len(self.contacts), self.name)
 
     def get_abook(self, name):
         """Get one of the backing abdress books by its name,

--- a/khard/config.py
+++ b/khard/config.py
@@ -216,20 +216,6 @@ class Config:
             raise ValueError("Error in config file\nInvalid value for %s "
                              "parameter\nPossible values: yes, no" % name)
 
-    def get_address_book(self, name, search_queries=None):
-        """
-        return address book object or None, if the address book with the
-        given name does not exist
-        :rtype: address_book.AddressBook
-        """
-        if not self.search_in_source_files():
-            search_queries = None
-        address_book = self.abook.get_abook(name)
-        if not address_book:
-            # Return None if no address book did match the given name.
-            return None
-        return address_book
-
     def has_uids(self):
         return self.config['contact table']['show_uids']
 

--- a/khard/config.py
+++ b/khard/config.py
@@ -9,7 +9,7 @@ import sys
 import configobj
 
 from .actions import Actions
-from .address_book import AddressBookCollection
+from .address_book import AddressBookCollection, VdirAddressBook
 
 
 def exit(message, prefix="Error in config file\n"):
@@ -176,12 +176,13 @@ class Config:
         if not self.config['addressbooks'].keys():
             exit("No address book entries available.")
         section = self.config['addressbooks']
+        kwargs = {'private_objects': self.get_supported_private_objects(),
+                  'localize_dates': self.localize_dates(),
+                  'skip': self.skip_unparsable()}
         try:
             self.abook = AddressBookCollection(
-                "tmp", *[(name, section[name]['path']) for name in section],
-                private_objects=self.get_supported_private_objects(),
-                localize_dates=self.localize_dates(),
-                skip=self.skip_unparsable())
+                "tmp", [VdirAddressBook(name, section[name]['path'], **kwargs)
+                        for name in section], **kwargs)
         except KeyError as err:
             exit('Missing path to the "{}" address book.'.format(err.args[0]))
         except IOError as err:

--- a/khard/config.py
+++ b/khard/config.py
@@ -36,7 +36,6 @@ class Config:
     def __init__(self, config_file=""):
         self.config = None
         self.abooks = []
-        self.uid_dict = {}
 
         # set locale
         locale.setlocale(locale.LC_ALL, '')
@@ -229,22 +228,10 @@ class Config:
         if not address_book:
             # Return None if no address book did match the given name.
             return None
-        # Check uniqueness of vcard uids and create short uid
-        # dictionary. This can be disabled with the show_uids option in
-        # the config file, if desired.
-        if self.config['contact table']['show_uids']:
-            self.uid_dict = self.abook.get_short_uid_dict(search_queries)
         return address_book
 
     def has_uids(self):
-        return bool(self.uid_dict)
-
-    def get_shortened_uid(self, uid):
-        if uid:
-            for length_of_uid in range(len(uid), 0, -1):
-                if self.uid_dict.get(uid[:length_of_uid]) is not None:
-                    return uid[:length_of_uid]
-        return ""
+        return self.config['contact table']['show_uids']
 
     def localize_dates(self):
         return self.config['contact table']['localize_dates']

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -577,15 +577,15 @@ def prepare_search_queries(args):
         escaped_term = ".*".join(re.escape(x)
                                  for x in args.source_search_terms)
         queries.append(escaped_term)
-        args.source_search_terms = ".*%s.*" % escaped_term
+        args.source_search_terms = escaped_term
     if "search_terms" in args and args.search_terms:
         escaped_term = ".*".join(re.escape(x) for x in args.search_terms)
         queries.append(escaped_term)
-        args.search_terms = ".*%s.*" % escaped_term
+        args.search_terms = escaped_term
     if "target_contact" in args and args.target_contact:
         escaped_term = re.escape(args.target_contact)
         queries.append(escaped_term)
-        args.target_contact = ".*%s.*" % escaped_term
+        args.target_contact = escaped_term
     if "uid" in args and args.uid:
         queries.append(args.uid)
     if "target_uid" in args and args.target_uid:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -591,7 +591,9 @@ def prepare_search_queries(args):
     if "target_uid" in args and args.target_uid:
         queries.append(args.target_uid)
     # create and return regexp
-    return "^.*(%s).*$" % ')|('.join(queries) if queries else None
+    queries = "^.*(%s).*$" % ')|('.join(queries) if queries else None
+    logging.debug('Created query regex: %s', queries)
+    return queries
 
 
 def generate_contact_list(config, args):

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -118,9 +118,8 @@ def modify_existing_contact(old_contact):
         # try to create contact from user input
         try:
             new_contact = \
-                    CarddavObject.from_existing_contact_with_new_user_input(
-                        old_contact, new_contact_template,
-                        config.localize_dates())
+                CarddavObject.from_existing_contact_with_new_user_input(
+                    old_contact, new_contact_template, config.localize_dates())
         except ValueError as err:
             print("\n%s\n" % err)
             while True:
@@ -137,8 +136,7 @@ def modify_existing_contact(old_contact):
             break
 
     # check if the user changed anything
-    if new_contact is None \
-            or old_contact == new_contact:
+    if new_contact is None or old_contact == new_contact:
         print("Nothing changed\n\n%s" % old_contact.print_vcard())
     else:
         new_contact.write_to_file(overwrite=True)
@@ -198,9 +196,9 @@ def merge_existing_contacts(source_contact, target_contact,
         # try to create contact from user input
         try:
             merged_contact = \
-                    CarddavObject.from_existing_contact_with_new_user_input(
-                        target_contact, merged_contact_template,
-                        config.localize_dates())
+                CarddavObject.from_existing_contact_with_new_user_input(
+                    target_contact, merged_contact_template,
+                    config.localize_dates())
         except ValueError as err:
             print("\n%s\n" % err)
             while True:
@@ -259,8 +257,7 @@ def copy_contact(contact, target_address_book, delete_source_contact):
         # if source file should be moved, get its file location to delete after
         # successful movement
         source_contact_filename = contact.filename
-    if not delete_source_contact \
-            or not contact.get_uid():
+    if not delete_source_contact or not contact.get_uid():
         # if copy contact or contact has no uid yet
         # create a new uid
         contact.delete_vcard_object("UID")
@@ -281,7 +278,7 @@ def copy_contact(contact, target_address_book, delete_source_contact):
 def list_address_books(address_book_list):
     table = [["Index", "Address book"]]
     for index, address_book in enumerate(address_book_list):
-        table.append([index+1, address_book.name])
+        table.append([index + 1, address_book.name])
     print(helpers.pretty_print(table))
 
 
@@ -311,9 +308,8 @@ def list_contacts(vcard_list):
     # table body
     for index, vcard in enumerate(vcard_list):
         row = []
-        row.append(index+1)
-        if vcard.get_nicknames() \
-                and config.show_nicknames():
+        row.append(index + 1)
+        if vcard.get_nicknames() and config.show_nicknames():
             if config.display_by_name() == "first_name":
                 row.append("%s (Nickname: %s)" % (
                     vcard.get_first_name_last_name(),
@@ -420,7 +416,7 @@ def choose_vcard_from_list(header_string, vcard_list):
                     sys.exit(0)
                 addr_index = int(input_string)
                 if addr_index > 0:
-                    selected_vcard = vcard_list[addr_index-1]
+                    selected_vcard = vcard_list[addr_index - 1]
                 else:
                     raise ValueError
             except (EOFError, IndexError, ValueError):
@@ -488,10 +484,10 @@ def get_contacts(address_books, query, method="all", reverse=False,
     else:
         if sort == "first_name":
             return sorted(contacts, reverse=reverse, key=lambda x:
-                    unidecode(x.get_first_name_last_name()).lower())
+                          unidecode(x.get_first_name_last_name()).lower())
         elif sort == "last_name":
             return sorted(contacts, reverse=reverse, key=lambda x:
-                    unidecode(x.get_last_name_first_name()).lower())
+                          unidecode(x.get_last_name_first_name()).lower())
         else:
             raise ValueError('sort must be "first_name" or "last_name" not '
                              '{}.'.format(sort))
@@ -602,8 +598,10 @@ def prepare_search_queries(args):
         target_queries.append(args.target_uid)
     # create and return regexp, None means that no query is given and hence all
     # contacts should be searched.
-    source_queries = "^.*(%s).*$" % ')|('.join(source_queries) if source_queries else None
-    target_queries = "^.*(%s).*$" % ')|('.join(target_queries) if target_queries else None
+    source_queries = "^.*(%s).*$" % ')|('.join(source_queries) \
+        if source_queries else None
+    target_queries = "^.*(%s).*$" % ')|('.join(target_queries) \
+        if target_queries else None
     logging.debug('Created source query regex: %s', source_queries)
     logging.debug('Created target query regex: %s', target_queries)
     # Get all possible search queries for address book parsing, always
@@ -745,8 +743,8 @@ def add_email_subcommand(input_from_stdin_or_file, selected_address_books):
     for line in input_from_stdin_or_file.splitlines():
         if line.startswith("From:"):
             try:
-                name = line[6:line.index("<")-1]
-                email_address = line[line.index("<")+1:line.index(">")]
+                name = line[6:line.index("<") - 1]
+                email_address = line[line.index("<") + 1:line.index(">")]
             except ValueError:
                 email_address = line[6:].strip()
             break
@@ -945,7 +943,7 @@ def phone_subcommand(search_terms, vcard_list, parsable):
                     # search string contains at least three digits.  So we
                     # remove all non-digit chars from the phone number field
                     # and match against that.
-                    if re.search(re.sub("\D", "", search_terms), \
+                    if re.search(re.sub("\D", "", search_terms),
                                  re.sub("\D", "", number), re.IGNORECASE):
                         matching_phone_number_list.append(phone_number_line)
                 # collect all phone numbers in a different list as fallback
@@ -1104,9 +1102,9 @@ def modify_subcommand(selected_vcard, input_from_stdin_or_file, open_editor):
         # create new contact from stdin
         try:
             new_contact = \
-                    CarddavObject.from_existing_contact_with_new_user_input(
-                        selected_vcard, input_from_stdin_or_file,
-                        config.localize_dates())
+                CarddavObject.from_existing_contact_with_new_user_input(
+                    selected_vcard, input_from_stdin_or_file,
+                    config.localize_dates())
         except ValueError as err:
             print(err)
             sys.exit(1)
@@ -1144,8 +1142,8 @@ def remove_subcommand(selected_vcard, force):
     if not force:
         while True:
             input_string = input(
-                "Deleting contact %s from address book %s. Are you sure? (y/n): "
-                % (selected_vcard, selected_vcard.address_book))
+                "Deleting contact %s from address book %s. Are you sure? "
+                "(y/n): " % (selected_vcard, selected_vcard.address_book))
             if input_string.lower() in ["", "n", "q"]:
                 print("Canceled")
                 sys.exit(0)
@@ -1738,8 +1736,7 @@ def main(argv=sys.argv[1:]):
                          args.parsable, args.remove_first_line)
     elif args.action == "list":
         list_subcommand(vcard_list, args.parsable)
-    elif args.action == "export" \
-            and "empty_contact_template" in args \
+    elif args.action == "export" and "empty_contact_template" in args \
             and args.empty_contact_template:
         # export empty template must work without selecting a contact first
         args.output_file.write(

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -1029,9 +1029,8 @@ def list_subcommand(vcard_list, parsable):
                 name = vcard.get_first_name_last_name()
             else:
                 name = vcard.get_last_name_first_name()
-            contact_line_list.append(
-                '\t'.join([config.get_shortened_uid(vcard.get_uid()), name,
-                           vcard.address_book.name]))
+            contact_line_list.append('\t'.join([vcard.get_uid(), name,
+                                                vcard.address_book.name]))
         print('\n'.join(contact_line_list))
     else:
         list_contacts(vcard_list)

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -579,28 +579,31 @@ def prepare_search_queries(args):
 
     """
     # get all possible search queries for address book parsing
-    queries = []
+    source_queries = []
+    target_queries = []
     if "source_search_terms" in args and args.source_search_terms:
         escaped_term = ".*".join(re.escape(x)
                                  for x in args.source_search_terms)
-        queries.append(escaped_term)
+        source_queries.append(escaped_term)
         args.source_search_terms = escaped_term
     if "search_terms" in args and args.search_terms:
         escaped_term = ".*".join(re.escape(x) for x in args.search_terms)
-        queries.append(escaped_term)
+        source_queries.append(escaped_term)
         args.search_terms = escaped_term
     if "target_contact" in args and args.target_contact:
         escaped_term = re.escape(args.target_contact)
-        queries.append(escaped_term)
+        target_queries.append(escaped_term)
         args.target_contact = escaped_term
     if "uid" in args and args.uid:
-        queries.append(args.uid)
+        source_queries.append(args.uid)
     if "target_uid" in args and args.target_uid:
-        queries.append(args.target_uid)
+        target_queries.append(args.target_uid)
     # create and return regexp
-    queries = "^.*(%s).*$" % ')|('.join(queries) if queries else None
-    logging.debug('Created query regex: %s', queries)
-    return queries
+    source_queries = "^.*(%s).*$" % ')|('.join(source_queries) if source_queries else None
+    target_queries = "^.*(%s).*$" % ')|('.join(target_queries) if target_queries else None
+    logging.debug('Created source query regex: %s', source_queries)
+    logging.debug('Created target query regex: %s', target_queries)
+    return source_queries, target_queries
 
 
 def generate_contact_list(config, args):
@@ -1657,15 +1660,15 @@ def main(argv=sys.argv[1:]):
         return
 
     merge_args_into_config(args, config)
-    search_queries = prepare_search_queries(args)
+    source_queries, target_queries = prepare_search_queries(args)
 
     # load address books
     if "addressbook" in args:
         args.addressbook = list(load_address_books(args.addressbook, config,
-                                                   search_queries))
+                                                   source_queries))
     if "target_addressbook" in args:
         args.target_addressbook = list(load_address_books(
-            args.target_addressbook, config, search_queries))
+            args.target_addressbook, config, target_queries))
 
     vcard_list = generate_contact_list(config, args)
 

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -1261,10 +1261,8 @@ def copy_or_move_subcommand(action, vcard_list, target_address_book_list):
               % (source_vcard, target_address_book_list[0]))
         sys.exit(1)
     else:
-        available_address_books = []
-        for address_book in target_address_book_list:
-            if address_book != source_vcard.address_book:
-                available_address_books.append(address_book)
+        available_address_books = [abook for abook in target_address_book_list
+                                   if abook != source_vcard.address_book]
         selected_target_address_book = choose_address_book_from_list(
             "Select target address book", available_address_books)
         if selected_target_address_book is None:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -533,6 +533,12 @@ def merge_args_into_config(args, config):
     # skip unparsable vcards
     if "skip_unparsable" in args and args.skip_unparsable:
         config.set_skip_unparsable(True)
+    # If the user could but did not specify address books on the command line
+    # it means they want to use all address books in that place.
+    if "addressbook" in args and not args.addressbook:
+        args.addressbook = [abook.name for abook in config.abooks]
+    if "target_addressbook" in args and not args.target_addressbook:
+        args.target_addressbook = [abook.name for abook in config.abooks]
 
 
 def load_address_books(names, config, search_queries=None):

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -13,6 +13,7 @@ from unidecode import unidecode
 
 from . import helpers
 from .actions import Actions
+from .address_book import AddressBookCollection
 from .carddav_object import CarddavObject
 from .config import Config
 from .version import khard_version
@@ -304,6 +305,12 @@ def list_contacts(vcard_list):
         table_header = ["Index", "Name", "Phone", "E-Mail", "Address book"]
     if config.has_uids():
         table_header.append("UID")
+        abook_collection = AddressBookCollection(
+            'short uids collection', selected_address_books,
+            private_objects=config.get_supported_private_objects(),
+            localize_dates=config.localize_dates(),
+            skip=config.skip_unparsable())
+
     table.append(table_header)
     # table body
     for index, vcard in enumerate(vcard_list):
@@ -343,8 +350,8 @@ def list_contacts(vcard_list):
         if len(selected_address_books) > 1:
             row.append(vcard.address_book.name)
         if config.has_uids():
-            if config.get_shortened_uid(vcard.get_uid()):
-                row.append(config.get_shortened_uid(vcard.get_uid()))
+            if abook_collection.get_short_uid(vcard.get_uid()):
+                row.append(abook_collection.get_short_uid(vcard.get_uid()))
             else:
                 row.append("")
         table.append(row)

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -47,10 +47,6 @@ def create_new_contact(address_book):
     temp_file_name = write_temp_file(template)
     temp_file_creation = helpers.file_modification_date(temp_file_name)
 
-    # read temp file contents before editing
-    with open(temp_file_name, "r") as tf:
-        old_contact_template = tf.read()
-
     while True:
         # start vim to edit contact template
         child = subprocess.Popen([config.editor, temp_file_name])


### PR DESCRIPTION
This PR is still a bit WIP.

I am trying to use the AddressBookCollection more.  At the same time I try to sort out the different paths that can and need to .load() an AddressBook.

The "Simplify derived search regex" commit (8b98889) gives me a bit of a speed improvement.

For measurements I use [this zsh function](https://github.com/lucc/shell-config/blob/master/functions/comp) to compare the execution time of 10 runs of a command:
```
$ comp './khard-runner.py ls -f' './khard-runner.py ls -f -a other' './khard-runner.py ls -f simon' './khard-runner.py ls -f -a other simon'
1  17.33s user 0.34s system 99% cpu 17.666 total
2  6.14s user 0.27s system 100% cpu 6.394 total
3  2.48s user 0.23s system 100% cpu 2.699 total
4  1.84s user 0.16s system 100% cpu 1.994 total
```
whereas on develop I get
```
1  17.37s user 0.39s system 99% cpu 17.773 total
2  13.71s user 0.40s system 99% cpu 14.119 total
3  2.40s user 0.29s system 99% cpu 2.691 total
4  2.35s user 0.23s system 99% cpu 2.580 total
```

The differences for the "all address books" commands should be within error margin but the times for the search in only one address book looks like a real speed improvement to me.