### PR TITLE
Fix travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ python:
   - "3.5"
   - "3.6"
   - "nightly" # currently points to 3.7-dev
-install: python setup.py install
+install: pip install .
 script: python -m unittest discover

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,8 @@ python:
   - "3.5"
   - "3.6"
   - "nightly" # currently points to 3.7-dev
+jobs:
+  allow_failures:
+    - python: "nightly"
 install: pip install .
 script: python -m unittest discover


### PR DESCRIPTION
Recently there have been some errors (not test failures) on travis. See https://travis-ci.org/scheibler/khard/builds and https://travis-ci.org/lucc/khard/builds .  As they are only for the nightly python version I think we can safely ignore them.