### PR TITLE
Add _email-khard mail completion.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Warning: If you want to create or modify contacts with khard, beware that the vc
 inconsistent and lacks interoperability. Different actors in that sector have defined their own
 extensions and even produce non-standard output. A good example is the type value, which is tied to
 phone numbers, email and post addresses. Khard tries to avoid such incompatibilities but if you sync
-your contacts with an Android or iOS device, expect problems. You are on the save side, if you only
+your contacts with an Android or iOS device, expect problems. You are on the safe side, if you only
 use khard to read contacts. For further information about the vcard compatibility issues have a look
 into [this blog post](http://alessandrorossini.org/2012/11/15/the-sad-story-of-the-vcard-format-and-its-lack-of-interoperability/).
 

--- a/misc/zsh/_email-khard
+++ b/misc/zsh/_email-khard
@@ -1,0 +1,15 @@
+#autoload
+
+_email-khard(){
+  OLDIFS=${IFS}
+  IFS=$'\n'
+  local khard_output=($(khard email -p 2>/dev/null))
+  IFS=$'\t'
+  for i in {1..${#khard_output[@]}}; do
+    local line=($(echo ${khard_output[$i]}))
+    reply+=(${line[1]})
+  done
+  IFS=${OLDIFS}
+  return 300
+}
+


### PR DESCRIPTION
ZSH supports mail completion plugins setup in files `_email-<plugin>`.
This file enables such completion for mails `khard` has access to.