### PR TITLE
README: fix mutt's config sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Khard may be used as an external address book for the email client mutt. To acco
 following to your mutt config file (mostly ~/.mutt/muttrc):
 
 ```
-set query_command = "xargs khard email --parsable -- <<< %s"
+set query_command = "echo %s | xargs khard email --parsable --"
 bind editor <Tab> complete-query
 bind editor ^T    complete
 ```
@@ -334,7 +334,7 @@ address books contain hundreds or even thousands of contacts and the query proce
 may try the --search-in-source-files option to speed up the search:
 
 ```
-set query_command = "xargs khard email --parsable --search-in-source-files -- <<< %s"
+set query_command = "echo %s | xargs khard email --parsable --search-in-source-files --"
 ```
 
 To add email addresses to khard's address book, you may also add the following lines to your muttrc file:

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Khard may be used as an external address book for the email client mutt. To acco
 following to your mutt config file (mostly ~/.mutt/muttrc):
 
 ```
-set query_command = "xargs khard email --parsable <<< %s"
+set query_command = "xargs khard email --parsable -- <<< %s"
 bind editor <Tab> complete-query
 bind editor ^T    complete
 ```
@@ -334,7 +334,7 @@ address books contain hundreds or even thousands of contacts and the query proce
 may try the --search-in-source-files option to speed up the search:
 
 ```
-set query_command = "xargs khard email --parsable --search-in-source-files <<< %s"
+set query_command = "xargs khard email --parsable --search-in-source-files -- <<< %s"
 ```
 
 To add email addresses to khard's address book, you may also add the following lines to your muttrc file:

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Khard may be used as an external address book for the email client mutt. To acco
 following to your mutt config file (mostly ~/.mutt/muttrc):
 
 ```
-set query_command= "khard email --parsable %s"
+set query_command = "xargs khard email --parsable <<< %s"
 bind editor <Tab> complete-query
 bind editor ^T    complete
 ```

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ address books contain hundreds or even thousands of contacts and the query proce
 may try the --search-in-source-files option to speed up the search:
 
 ```
-set query_command= "khard email --parsable --search-in-source-files '%s'"
+set query_command = "xargs khard email --parsable --search-in-source-files <<< %s"
 ```
 
 To add email addresses to khard's address book, you may also add the following lines to your muttrc file:

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ Khard may be used as an external address book for the email client mutt. To acco
 following to your mutt config file (mostly ~/.mutt/muttrc):
 
 ```
-set query_command= "khard email --parsable '%s'"
+set query_command= "khard email --parsable %s"
 bind editor <Tab> complete-query
 bind editor ^T    complete
 ```


### PR DESCRIPTION
Remove single quotes from the query_command in the mutt config sample to fix
code injection vulnerability

mutt already escapes arguments (%s) with single quotes.
mutt's manual states the following:
> This specifies the command Mutt will use to make external address queries.  The string may contain a
> “%s”,  which  will be substituted with the query string the user types.  Mutt will add quotes around
> the string substituted for “%s” automatically according to shell quoting rules, so you should  avoid
> adding your own.  If no “%s” is found in the string, Mutt will append the user's query to the end of
> the string.  See “query” for more information.


When `query_command` contains `'%s'`, the quotes are doubled by mutt.
`khard email --parsable '%s'` becomes `khard email --parsable ''Dave Null''` and is parsed by the shell as `["khard", "email", "parsable", "Dave", "Null"]`

While this may cause troubles with Irish names (O'Foobar), it also makes it possible to run arbitrary command from mutt's `From` field, by using special characters.
Auto-completing `; bash;` will result in mutt spawning a bash shell.
```
mutt
└─ sh -c khard email --parsable ''; bash; ''
   └─ bash
```

The exploitation of this vulnerability by an attacker is very unlikely.
Note that it is also possible to fix this by removing %s altogether.