### PR TITLE
Display ABLABELs for URLs and Private Objects

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -57,6 +57,7 @@ def convert_to_vcard(name, value, allowed_object_type):
     raise ValueError("Error: " + name +
                      " must be a string or a list with strings.")
 
+
 class VCardWrapper:
     """Wrapper class around a vobject.vCard object.
 
@@ -392,7 +393,7 @@ class VCardWrapper:
             if len(user_input) > 1:
                 raise ValueError("Error: %s must be a string or a dict " +\
                                  "containing one key/value pair." % obj_type)
-            label = [i for i in user_input][0]
+            label = list(user_input)[0]
             group_name = self._get_new_group(obj_type if name_groups else "")
             obj.group = group_name
             obj.value = convert_to_vcard(obj_type, user_input[label],

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -121,6 +121,9 @@ class VCardWrapper:
         value.  This function returnes them untouched inside an agregating
         list.
 
+        If the property is part of a group containing exactly two items, with
+        exactly one ABLABEL. the property will be prefixed with that ABLABEL.
+
         :param name: the name of the property (should be UPPER case)
         :type name: str
         :returns: the values from all occurences of the named property
@@ -129,7 +132,8 @@ class VCardWrapper:
         values = []
         for child in self.vcard.getChildren():
             if child.name == name:
-                values.append(child.value)
+                ablabel = self._get_ablabel(child)
+                values.append(ablabel + (": " if ablabel else "") + child.value)
         return sorted(values)
 
     def _delete_vcard_object(self, name):
@@ -332,6 +336,53 @@ class VCardWrapper:
             except (AttributeError, ValueError):
                 pass
         return None
+
+    def _get_ablabel(self, item):
+        """Get an ABLABEL for a specified item in the vCard.
+        Will return the ABLABEL only if the item is part of a group with exactly
+        two items, exactly one of which is an ABLABEL.
+
+        :param item: the item to be labelled
+        :type item: vobject.base.ContentLine
+        :returns: the ABLABEL in the circumstances above or an empty string
+        :rtype: str
+
+        """
+        label = ""
+        if item.group:
+            count = 0
+            for child in self.vcard.getChildren():
+                if child.group and child.group == item.group:
+                    count += 1
+                    if child.name == "X-ABLABEL":
+                        if label == "":
+                            label = child.value
+                        else:
+                            return ""
+            if count != 2:
+                label = ""
+        return label
+
+    def _get_new_group(self, group_type=""):
+        """Get an unused group name for adding new groups. Uses the form item123
+         or itemgroup_type123 if a grouptype is specified.
+
+        :param group_type: (Optional) a string to add between "item" and the
+                           number
+        :type group_type: str
+        :returns: the name of the first unused group of the specified form
+        :rtype: str
+
+        """
+        counter = 1
+        while True:
+            group_name = "item%s%d" % (group_type, counter)
+            for child in self.vcard.getChildren():
+                if child.group and child.group ==  group_name:
+                    counter += 1
+                    break
+            else:
+                return group_name
 
     @anniversary.setter
     def anniversary(self, date):
@@ -567,14 +618,26 @@ class VCardWrapper:
     @property
     def webpages(self):
         """
-        :rtype: list(list(str))
+        :rtype: list(str)
         """
         return self._get_multi_property("URL")
 
     def _add_webpage(self, webpage):
         webpage_obj = self.vcard.add('url')
-        webpage_obj.value = convert_to_vcard("webpage", webpage,
-                                             ObjectType.string)
+        if isinstance(webpage, dict):
+            if len(webpage) > 1:
+                raise ValueError(
+                    "Error: webpage must be a string.")
+            label = [i for i in webpage][0]
+            group_name = self._get_new_group()
+            webpage_obj.group = group_name
+            webpage_obj.value = webpage[label]
+            ablabel_obj = self.vcard.add('X-ABLABEL')
+            ablabel_obj.group = group_name
+            ablabel_obj.value = label
+        else:
+            webpage_obj.value = helpers.convert_to_vcard("webpage", webpage,
+                                                         ObjectType.string)
 
     @property
     def categories(self):
@@ -1010,7 +1073,8 @@ class CarddavObject(VCardWrapper):
                     key = self.supported_private_objects[key_index]
                     if key not in private_objects:
                         private_objects[key] = []
-                    private_objects[key].append(child.value)
+                    ablabel = self._get_ablabel(child)
+                    private_objects[key].append(ablabel + (": " if ablabel else "") + child.value)
         # sort private object lists
         for value in private_objects.values():
             value.sort()
@@ -1018,7 +1082,20 @@ class CarddavObject(VCardWrapper):
 
     def _add_private_object(self, key, value):
         private_obj = self.vcard.add('X-' + key.upper())
-        private_obj.value = convert_to_vcard(key, value, ObjectType.string)
+        if isinstance(value, dict):
+            if len(value) > 1:
+                raise ValueError(
+                    "Error: " + key + " must be a string.")
+            label = [i for i in value][0]
+            group_name = self._get_new_group()
+            private_obj.group = group_name
+            private_obj.value = value[label]
+            ablabel_obj = self.vcard.add('X-ABLABEL')
+            ablabel_obj.group = group_name
+            ablabel_obj.value = label
+        else:
+            private_obj.value = helpers.convert_to_vcard(key, value,
+                                                         ObjectType.string)
 
     def get_formatted_anniversary(self):
         return self._format_date_object(self.anniversary, self.localize_dates)

--- a/test/test_carddav_object.py
+++ b/test/test_carddav_object.py
@@ -474,3 +474,13 @@ class CarddavObjectFormatDateObject(unittest.TestCase):
         d = datetime.datetime(1900, 2, 13)
         actual = carddav_object.CarddavObject._format_date_object(d, False)
         self.assertEqual(actual, '--02-13')
+
+class ABLabels(unittest.TestCase):
+
+    def test_setting_and_getting_webpage_ablabel(self):
+        vcard = _create_test_vcard()
+        wrapper = carddav_object.VCardWrapper(vcard)
+        wrapper._add_webpage({'github':'https://github.com/scheibler/khard'})
+        wrapper._add_webpage('http://example.com')
+        self.assertListEqual(wrapper.webpages, [
+            'github: https://github.com/scheibler/khard', 'http://example.com'])

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -73,3 +73,28 @@ class EmptyFieldsAndSpaces(unittest.TestCase):
         empty_note = "First name: foo\nNote:"
         x = self._parse_yaml(empty_note)
         self.assertListEqual(x.notes, [])
+
+class yaml_ablabel(unittest.TestCase):
+
+    @staticmethod
+    def _parse_yaml(yaml=''):
+        """Parse some yaml string into a CarddavObject
+
+        :param yaml: the yaml input string to parse
+        :type yaml: str
+        :returns: the parsed CarddavObject
+        :rtype: CarddavObject
+        """
+        # Careful, this function doesn't actually support named arguments so
+        # they have to be kept in this order!
+        return CarddavObject.from_user_input(
+                address_book=mock.Mock(path='foo-path'), user_input=yaml,
+                supported_private_objects=[], version='3.0',
+                localize_dates=False)
+
+    def test_ablabelled_url_in_yaml_input(self):
+        ablabel_url = "First name: foo\nWebpage:\n - http://example.com\n" +\
+                      " - github: https://github.com/scheibler/khard"
+        x = self._parse_yaml(ablabel_url)
+        self.assertListEqual(x.webpages, [
+            'github: https://github.com/scheibler/khard', 'http://example.com'])

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -93,7 +93,7 @@ class yaml_ablabel(unittest.TestCase):
                 localize_dates=False)
 
     def test_ablabelled_url_in_yaml_input(self):
-        ablabel_url = "First name: foo\nWebpage:\n - http://example.com\n" +\
+        ablabel_url = "First name: foo\nWebpage:\n - http://example.com\n" \
                       " - github: https://github.com/scheibler/khard"
         x = self._parse_yaml(ablabel_url)
         self.assertListEqual(x.webpages, [


### PR DESCRIPTION
Also enable adding/editing these.

Recreated #202 because the merge onto develop wasn't possible without (someone else's) manual intervention.

I still need to add tests.