### PR TITLE
Handle case where _get_multi_property() encounters a list instead of …

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -134,7 +134,7 @@ class VCardWrapper:
             if child.name == name:
                 ablabel = self._get_ablabel(child)
                 if ablabel:
-                    values.append(ablabel + ": " + child.value)
+                    values.append(ablabel + ": " + "".join(child.value))
                 else:
                     values.append(child.value)
         return sorted(values)


### PR DESCRIPTION
…a string.

In the ABLABEL-related code in `_get_multi_property()` it assumes the result is a string. Today I encountered one that presented itself as a list (containing a single string). This should handle strings, lists containing a single string and (slightly messily) longer lists.

I'm open to suggestions if you have a better idea.