### PR TITLE
Use dict internally for fields with ABLABEL

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -574,7 +574,10 @@ class VCardWrapper:
         # check if fn attribute is already present
         if not self.vcard.getChildValue("fn") and self.organisations:
             # if not, set fn to organisation name
-            org_value = helpers.list_to_string(self.organisations[0], ", ")
+            first_org = self.organisations[0]
+            if isinstance(first_org, dict):
+                first_org = list(first_org.values())[0]
+            org_value = helpers.list_to_string(first_org, ", ")
             self.formatted_name = org_value.replace("\n", " ").replace("\\",
                                                                        "")
             showas_obj = self.vcard.add('x-abshowas')

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -570,7 +570,8 @@ class VCardWrapper:
         :param str|list(str) organisation: the value to add
         :returns: None
         """
-        self._add_labelled_object("org", organisation, True, ObjectType.list_with_strings)
+        self._add_labelled_object("org", organisation, True,
+            ObjectType.list_with_strings)
         # check if fn attribute is already present
         if not self.vcard.getChildValue("fn") and self.organisations:
             # if not, set fn to organisation name
@@ -586,52 +587,47 @@ class VCardWrapper:
     @property
     def titles(self):
         """
-        :rtype: list(list(str))
+        :rtype: list(str or dict(str))
         """
         return self._get_multi_property("TITLE")
 
     def _add_title(self, title):
-        title_obj = self.vcard.add('title')
-        title_obj.value = convert_to_vcard("title", title, ObjectType.string)
+        self._add_labelled_object("title", title, True)
 
     @property
     def roles(self):
         """
-        :rtype: list(list(str))
+        :rtype: list(str or dict(str))
         """
         return self._get_multi_property("ROLE")
 
     def _add_role(self, role):
-        role_obj = self.vcard.add('role')
-        role_obj.value = convert_to_vcard("role", role, ObjectType.string)
+        self._add_labelled_object("role", role, True)
 
     @property
     def nicknames(self):
         """
-        :rtype: list(list(str))
+        :rtype: list(str or dict(str))
         """
         return self._get_multi_property("NICKNAME")
 
     def _add_nickname(self, nickname):
-        nickname_obj = self.vcard.add('nickname')
-        nickname_obj.value = convert_to_vcard("nickname", nickname,
-                                              ObjectType.string)
+        self._add_labelled_object("nickname", nickname, True)
 
     @property
     def notes(self):
         """
-        :rtype: list(list(str))
+        :rtype: list(str or dict(str))
         """
         return self._get_multi_property("NOTE")
 
     def _add_note(self, note):
-        note_obj = self.vcard.add('note')
-        note_obj.value = convert_to_vcard("note", note, ObjectType.string)
+        self._add_labelled_object("note", note, True)
 
     @property
     def webpages(self):
         """
-        :rtype: list(str)
+        :rtype: list(str or dict(str))
         """
         return self._get_multi_property("URL")
 

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -937,7 +937,7 @@ class YAMLEditable(VCardWrapper):
                     {ablabel: child.value} if ablabel else child.value)
         # sort private object lists
         for value in private_objects.values():
-            value.sort()
+            value.sort(key=multi_property_key)
         return private_objects
 
     def _add_private_object(self, key, value):

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -57,6 +57,13 @@ def convert_to_vcard(name, value, allowed_object_type):
                      " must be a string or a list with strings.")
 
 
+def multi_property_key(item):
+    if isinstance(item, dict) or isinstance(item, list):
+        return list(item)[0]
+    else:
+        return item
+
+
 class VCardWrapper:
     """Wrapper class around a vobject.vCard object.
 
@@ -136,8 +143,7 @@ class VCardWrapper:
                     values.append({ablabel: child.value})
                 else:
                     values.append(child.value)
-        #return sorted(values)
-        return values
+        return sorted(values, key=multi_property_key)
 
     def _delete_vcard_object(self, name):
         """Delete all fields with the given name from the underlying vCard.

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -58,10 +58,20 @@ def convert_to_vcard(name, value, allowed_object_type):
 
 
 def multi_property_key(item):
-    if isinstance(item, dict) or isinstance(item, list):
-        return list(item)[0]
+    """key function to pass to sorted(), allowing sorting of dicts with lists
+    and strings. Dicts will be sorted by their label, after other types.
+
+    :param item: member of the list being sorted
+    :type item: a dict with a single entry or any sortable type
+    :returns: a list with two members. The first is int(isinstance(item, dict).
+        The second is either the key from the dict or the unchanged item if it
+        is not a dict.
+    :rtype list(int, type(item)) or list(int, str)
+    """
+    if isinstance(item, dict):
+        return [1, list(item)[0]]
     else:
-        return item
+        return [0, item]
 
 
 class VCardWrapper:
@@ -386,6 +396,19 @@ class VCardWrapper:
 
     def _add_labelled_object(self, obj_type, user_input, name_groups=False,
                              allowed_object_type=ObjectType.string):
+        """Add an object to the VCARD. If user_input is a dict, the object will
+         be added to a group with an ABLABEL created from the key of the dict.
+
+        :param str obj_type: type of object to add to the VCARD.
+        :param user_input: Contents of the object to add. If a dict
+        :type user_input: str or list(str) or dict(str) or dict(list(str))
+        :param bool name_groups: (Optional) If True, use the obj_type in the
+            group name for labelled objects.
+        :param allowed_object_type: (Optional) set the accepted return type
+            for vcard attribute
+        :type allowed_object_type: enum of type ObjectType
+        :returns: None
+        """
         obj = self.vcard.add(obj_type)
         if isinstance(user_input, dict):
             if len(user_input) > 1:
@@ -571,7 +594,7 @@ class VCardWrapper:
         :returns: None
         """
         self._add_labelled_object("org", organisation, True,
-            ObjectType.list_with_strings)
+                                  ObjectType.list_with_strings)
         # check if fn attribute is already present
         if not self.vcard.getChildValue("fn") and self.organisations:
             # if not, set fn to organisation name

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -560,7 +560,7 @@ class VCardWrapper:
     def organisations(self):
         """
         :returns: list of organisations, sorted alphabetically
-        :rtype: list(list(str))
+        :rtype: list(list(str) or dict(list(str)))
         """
         return self._get_multi_property("ORG")
 

--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -171,7 +171,8 @@ def convert_to_yaml(name, value, indentation, index_of_colon,
             elif isinstance(outer, dict):
                 # ABLABEL'd lists
                 for k in outer:
-                    strings += convert_to_yaml("- " + k, outer[k], indentation+4, index_of_colon, show_multi_line_character)
+                    strings += convert_to_yaml("- " + k, outer[k], indentation+4,
+                        index_of_colon, show_multi_line_character)
     return strings
 
 

--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -118,7 +118,7 @@ def convert_to_yaml(name, value, indentation, index_of_colon,
 
     :param str name: name of object (example: phone)
     :param value: object contents
-    :type value: str, list(str), list(list(str))
+    :type value: str, list(str), list(list(str)), list(dict)
     :param str indentation: indent all by number of spaces
     :param int index_of_colon: use to position : at the name string (-1 for no
         space)
@@ -168,6 +168,10 @@ def convert_to_yaml(name, value, indentation, index_of_colon,
                             ' ' * (indentation+8), indent_multiline_string(
                                 inner, indentation+12,
                                 show_multi_line_character)))
+            elif isinstance(outer, dict):
+                # ABLABEL'd lists
+                for k in outer:
+                    strings += convert_to_yaml("- " + k, outer[k], indentation+4, index_of_colon, show_multi_line_character)
     return strings
 
 

--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -171,8 +171,9 @@ def convert_to_yaml(name, value, indentation, index_of_colon,
             elif isinstance(outer, dict):
                 # ABLABEL'd lists
                 for k in outer:
-                    strings += convert_to_yaml("- " + k, outer[k], indentation+4,
-                        index_of_colon, show_multi_line_character)
+                    strings += convert_to_yaml(
+                        "- " + k, outer[k], indentation+4, index_of_colon,
+                        show_multi_line_character)
     return strings
 
 

--- a/test/test_vcard_wrapper.py
+++ b/test/test_vcard_wrapper.py
@@ -467,8 +467,13 @@ class ABLabels(unittest.TestCase):
             {'github': 'https://github.com/scheibler/khard'},
             'http://example.com'])
 
-    @unittest.expectedFailure
     def test_labels_on_structured_values(self):
         vcard = VCardWrapper(_from_file('test/fixture/vcards/labels.vcf'))
-        # TODO find a solution for issue #221
-        self.assertListEqual(vcard.organisations, ['Test Inc'])
+        self.assertListEqual(vcard.organisations, [{'Work': ['Test Inc']}])
+
+    def test_setting_and_getting_webpages(self):
+        vcard = create_test_vcard()
+        wrapper = VCardWrapper(vcard)
+        wrapper._delete_vcard_object("FN")
+        wrapper._add_organisation({'Work': ['Test Inc']})
+        self.assertEqual(wrapper.formatted_name, 'Test Inc')

--- a/test/test_vcard_wrapper.py
+++ b/test/test_vcard_wrapper.py
@@ -464,7 +464,7 @@ class ABLabels(unittest.TestCase):
         wrapper._add_webpage({'github': 'https://github.com/scheibler/khard'})
         wrapper._add_webpage('http://example.com')
         self.assertListEqual(wrapper.webpages, [
-            'github: https://github.com/scheibler/khard',
+            {'github': 'https://github.com/scheibler/khard'},
             'http://example.com'])
 
     @unittest.expectedFailure

--- a/test/test_vcard_wrapper.py
+++ b/test/test_vcard_wrapper.py
@@ -464,14 +464,14 @@ class ABLabels(unittest.TestCase):
         wrapper._add_webpage({'github': 'https://github.com/scheibler/khard'})
         wrapper._add_webpage('http://example.com')
         self.assertListEqual(wrapper.webpages, [
-            {'github': 'https://github.com/scheibler/khard'},
-            'http://example.com'])
+            'http://example.com',
+            {'github': 'https://github.com/scheibler/khard'}])
 
     def test_labels_on_structured_values(self):
         vcard = VCardWrapper(_from_file('test/fixture/vcards/labels.vcf'))
         self.assertListEqual(vcard.organisations, [{'Work': ['Test Inc']}])
 
-    def test_setting_and_getting_webpages(self):
+    def test_setting_fn_from_labelled_org(self):
         vcard = create_test_vcard()
         wrapper = VCardWrapper(vcard)
         wrapper._delete_vcard_object("FN")

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -116,7 +116,7 @@ class yaml_ablabel(unittest.TestCase):
                       " - github: https://github.com/scheibler/khard"
         x = self._parse_yaml(ablabel_url)
         self.assertListEqual(x.webpages, [
-            'github: https://github.com/scheibler/khard', 'http://example.com'])
+            {'github': 'https://github.com/scheibler/khard'}, 'http://example.com'])
 
 
 class UpdateVcardWithYamlUserInput(unittest.TestCase):

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -116,7 +116,8 @@ class yaml_ablabel(unittest.TestCase):
                       " - github: https://github.com/scheibler/khard"
         x = self._parse_yaml(ablabel_url)
         self.assertListEqual(x.webpages, [
-            {'github': 'https://github.com/scheibler/khard'}, 'http://example.com'])
+            'http://example.com',
+            {'github': 'https://github.com/scheibler/khard'}])
 
 
 class UpdateVcardWithYamlUserInput(unittest.TestCase):


### PR DESCRIPTION
Also allow for ABLABELs in `_add_organisation`.

Fixes #221, #225.

Still needs handling for ADR (maybe others?) and unit tests. Feedback welcome, but I might not get back to this until next week, so here's a start.

~~In its current form, this also breaks sorting in` _get_multi_property`, which causes several tests to fail.~~