### PR TITLE
Force strings that look like yaml mapping values to be displayed as multiline strings

### DIFF
--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -118,7 +118,7 @@ def convert_to_yaml(name, value, indentation, index_of_colon,
     :param str name: name of object (example: phone)
     :param value: object contents
     :type value: str, list(str), list(list(str)), list(dict)
-    :param str indentation: indent all by number of spaces
+    :param int indentation: indent all by number of spaces
     :param int index_of_colon: use to position : at the name string (-1 for no
         space)
     :param bool show_multi_line_character: option to hide "|"
@@ -181,7 +181,7 @@ def indent_multiline_string(input, indentation, show_multi_line_character):
     if isinstance(input, list):
         input = list_to_string(input, "")
     # format multiline string
-    if "\n" in input:
+    if "\n" in input or ": " in input:
         lines = ["|"] if show_multi_line_character else [""]
         for line in input.split("\n"):
             lines.append("%s%s" % (' ' * indentation, line.strip()))

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -102,5 +102,12 @@ class StringToDate(unittest.TestCase):
         self.assertEqual(result, self.zone)
 
 
+class ConvertToYAML(unittest.TestCase):
+
+    def test_colon_handling(self):
+        result = helpers.convert_to_yaml("Note", "foo: bar", 0, 5, True)
+        self.assertEqual(result[0], "Note : |\n    foo: bar")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
As @lucc discovered in while testing #226, a string containing ": " will be output into a yaml as a normal string, but will then fail to parse because it looks like a yaml mapping value.

This patch works around that problem by forcing any string containing ": " to be output into yaml as a multiline string, where such sequences are ignored. I've also included a test for the round trip, which should hopefully work even if the implementation of the fix changes.