### PR TITLE
Move mentioning of the authors to README

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,0 @@
-Eric Scheibler - email [at] eric-scheibler [dot] de - http://eric-scheibler.de

--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,14 @@ are welcome to post `bug reports <https://github.com/scheibler/khard/issues>`_
 and `feature requests <https://github.com/scheibler/khard/pulls>`_.  Also see
 the `notes for contributors <doc/source/contributing.rst>`_.
 
+Authors
+-------
+
+Khard was started by `Eric Scheibler <http://eric-scheibler.de>`_ and is
+currently maintained by @lucc.  `Several people
+<https://github.com/scheibler/khard/graphs/contributors>`_ have contributed
+over the years.
+
 Related projects
 ----------------
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -49,7 +49,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'khard'
-copyright = '2018, Eric Scheibler'
+copyright = '2019, Eric Scheibler'
 author = 'Eric Scheibler'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
@scheibler I do not know if the AUTHORS file served any kind of purpos or if
any tool needs it.  If it is just for humans I would rather put this info
into the readme which is now not our main documentation document any longer.

I left you as the author in the docs.  I hope that is ok with you.