### PR TITLE
Make the build reproducible

### DIFF
--- a/khard/config.py
+++ b/khard/config.py
@@ -92,7 +92,6 @@ def validate_private_objects(value):
 class Config:
 
     supported_vcard_versions = ("3.0", "4.0")
-    SPEC_FILE = os.path.join(os.path.dirname(__file__), 'data', 'config.spec')
 
     def __init__(self, config_file=None):
         self.config = None
@@ -115,9 +114,11 @@ class Config:
                                         os.path.expanduser("~/.config"))
             config_file = os.getenv("KHARD_CONFIG", os.path.join(
                 xdg_config_home, "khard", "khard.conf"))
+        configspec = os.path.join(os.path.dirname(__file__),
+                                  'data', 'config.spec')
         try:
             return configobj.ConfigObj(
-                infile=config_file, configspec=cls.SPEC_FILE,
+                infile=config_file, configspec=configspec,
                 interpolation=False, file_error=True)
         except configobj.ConfigObjError as err:
             exit(str(err))

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -148,7 +148,9 @@ class Validation(unittest.TestCase):
 
     @staticmethod
     def _template(section, key, value):
-        c = configobj.ConfigObj(configspec=config.Config.SPEC_FILE)
+        configspec = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                                  'khard', 'data', 'config.spec')
+        c = configobj.ConfigObj(configspec=configspec)
         c['general'] = {}
         c['vcard'] = {}
         c['contact table'] = {}


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that *khard* could not be built reproducibly.

This is because it includes the absolute build directory in the documentation via the `SPEC_FILE` attribute. This commit calculates this value dynamically instead.

(This was originally filed in Debian as [#943471](https://bugs.debian.org/943471).)