### PR TITLE
Works fine on macOS and the *BSDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 khard
 =====
 
-Khard is an address book for the Linux console. It creates, reads, modifies and
+Khard is an address book for the Unix console. It creates, reads, modifies and
 removes carddav address book entries at your local machine. Khard is also
 compatible to the email clients mutt and alot and the SIP client twinkle. You
 can find more information about khard and the whole synchronization process

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,7 +13,7 @@ Welcome to khard's documentation!
    API documentation for developers <api/modules.rst>
    indices
 
-Khard is an address book for the Linux command line.  It can read, create,
+Khard is an address book for the Unix command line.  It can read, create,
 modify and delete carddav address book entries.  Khard only works with a local
 store of VCARD files.  It is intended to be used in conjunction with other
 programs like an email client, text editor, vdir synchronizer or VOIP client.
@@ -26,7 +26,7 @@ Installation
    :target: https://repology.org/project/khard/versions
    :alt: Packaging status
 
-Khard is available as a native package for some Linux distributions so you
+Khard is available as a native package for some *nix distributions so you
 should check your package manager first.  If you want or need to install
 manually you can use the release from `PyPi`_:
 

--- a/doc/source/man/khard.rst
+++ b/doc/source/man/khard.rst
@@ -13,7 +13,7 @@ Synopsis
 Description
 -----------
 
-:program:`khard` is an address book for the Linux command line.  It can read, create,
+:program:`khard` is an address book for the Unix command line.  It can read, create,
 modify and delete carddav address book entries.  :program:`khard` only works with a local
 store of VCARD files.  It is intended to be used in conjunction with other
 programs like an email client, text editor, vdir synchronizer or VOIP client.


### PR DESCRIPTION
The current wording may, falsely, imply that `khard` runs is Linux-only, which isn't the case.