### PR TITLE
Command line interface: Implement --fields for list command

### DIFF
--- a/khard/cli.py
+++ b/khard/cli.py
@@ -159,6 +159,10 @@ def create_parsers():
     list_parser.add_argument(
         "-p", "--parsable", action="store_true",
         help="Machine readable format: uid\\tcontact_name\\taddress_book_name")
+    list_parser.add_argument(
+        "-F", "--fields", default=['index', 'name', 'phone', 'email', 'uid'],
+        type=lambda x: [y.strip() for y in x.split(",")],
+        help="Comma separated list of fields to show (default index,name,phone,email,uid)")
     show_parser = subparsers.add_parser(
         "show",
         aliases=Actions.get_aliases("show"),

--- a/khard/cli.py
+++ b/khard/cli.py
@@ -160,9 +160,9 @@ def create_parsers():
         "-p", "--parsable", action="store_true",
         help="Machine readable format: uid\\tcontact_name\\taddress_book_name")
     list_parser.add_argument(
-        "-F", "--fields", default=['index', 'name', 'phone', 'email', 'uid'],
+        "-F", "--fields", default=[],
         type=lambda x: [y.strip() for y in x.split(",")],
-        help="Comma separated list of fields to show (default index,name,phone,email,uid)")
+        help="Comma separated list of fields to show")
     show_parser = subparsers.add_parser(
         "show",
         aliases=Actions.get_aliases("show"),

--- a/khard/cli.py
+++ b/khard/cli.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 def field_argument(orignal):
-    """Check that the field specification for `ls -F` start with a propper
-    field name.  Nested attribute names are not checked.
+    """Ensure the fields specified for `ls -F` are proper field names.
+    Nested attribute names are not checked.
 
     :param str orignal: the value from the command line
     :returns: the orignal value split at "," if the fields are spelled correctly
@@ -34,7 +34,7 @@ def field_argument(orignal):
             ret.append(candidate)
         else:
             raise argparse.ArgumentTypeError(
-                '"{}" is not an acepted fiels. Acepted fields are {}.'.format(
+                '"{}" is not an accepted field. Accepted fields are {}.'.format(
                     field, ', '.join('"{}"'.format(c) for c in choices)))
     return ret
 

--- a/khard/helpers.py
+++ b/khard/helpers.py
@@ -8,6 +8,8 @@ from datetime import datetime
 
 
 def pretty_print(table, justify="L"):
+    """Converts a list of lists into a string formatted like a table
+    with spaces separating fields and newlines separating rows"""
     # support for multiline columns
     line_break_table = []
     for row in table:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -375,7 +375,8 @@ def get_nested_field(vcard, field):
                 val = val[partial.upper()]
             else:
                 val = ''
-    return val
+    # Convert None and other falsy values to the empty string
+    return val or ''
 
 
 def get_special_field(vcard, field):

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -298,6 +298,7 @@ def list_address_books(address_books):
 
 
 def pretty_name(name):
+    """Convert snake_cased column into their pretty alternative."""
     # Note: ugly_name should give the key for each of these.
     field = {
         'index': "Index",
@@ -313,6 +314,7 @@ def pretty_name(name):
 
 
 def ugly_name(name):
+    """Convert SOME field-names into their_snakecase format."""
     return name.replace('-', '').replace(' ', '_').lower()
 
 
@@ -400,6 +402,8 @@ def get_nested_field(vcard, field):
 
 
 def get_special_field(vcard, field):
+    """Returns certain fields with specific formatting options
+        (for support of some list command options)."""
     if field == 'name':
         if vcard.nicknames and config.show_nicknames:
             if config.display == "first_name":
@@ -1038,6 +1042,8 @@ def list_subcommand(vcard_list, parsable, fields):
     :type vcard_list: list of carddav_object.CarddavObject
     :param parsable: machine readable output: columns devided by tabulator (\t)
     :type parsable: bool
+    :param fields: list of strings for field evaluation
+    :type fields: list
     :returns: None
     :rtype: None
 

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -297,27 +297,6 @@ def list_address_books(address_books):
     print(helpers.pretty_print(table))
 
 
-def pretty_name(name):
-    """Convert snake_cased column into their pretty alternative."""
-    # Note: ugly_name should give the key for each of these.
-    field = {
-        'index': "Index",
-        'name': "Name",
-        'phone': "Phone",
-        'email': "E-Mail",
-        'address_book': "Address book",
-        'uid': "UID",
-    }
-    if name in field:
-        return field[name]
-    return name
-
-
-def ugly_name(name):
-    """Convert SOME field-names into their_snakecase format."""
-    return name.replace('-', '').replace(' ', '_').lower()
-
-
 def list_contacts(vcard_list, fields=[], parsable=False):
     selected_address_books = []
     for contact in vcard_list:
@@ -333,22 +312,22 @@ def list_contacts(vcard_list, fields=[], parsable=False):
         if not parsable:
             print("Address books: {}".format(', '.join(
                 [str(book) for book in selected_address_books])))
-        table_header = ["index", "name", "phone", "email", "addressbook"]
+        table_header = ["index", "name", "phone", "email", "address_book"]
     if config.show_uids:
         table_header.append("uid")
 
     if parsable:
         # Legacy default header fields for parsable.
-        table_header = ["uid", "name", "addressbook"]
+        table_header = ["uid", "name", "address_book"]
 
     if fields:
-        table_header = [ugly_name(x) for x in fields]
+        table_header = [x.lower().replace(' ','_') for x in fields]
 
     abook_collection = AddressBookCollection('short uids collection',
                                              selected_address_books)
 
     if not parsable:
-        table.append([pretty_name(x) for x in table_header])
+        table.append([x.title().replace('_', ' ') for x in table_header])
     # table body
     for index, vcard in enumerate(vcard_list):
         row = []
@@ -357,8 +336,6 @@ def list_contacts(vcard_list, fields=[], parsable=False):
                 row.append(index + 1)
             elif field in ['name', 'phone', 'email']:
                 row.append(get_special_field(vcard, field))
-            elif field == 'addressbook':
-                row.append(vcard.address_book.name)
             elif field == 'uid':
                 if parsable:
                     row.append(vcard.uid)

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -385,14 +385,13 @@ def get_special_field(vcard, field):
     if field == 'name':
         if vcard.nicknames and config.show_nicknames:
             if config.display == "first_name":
-                return"{} (Nickname: {})".format(
+                return "{} (Nickname: {})".format(
                     vcard.get_first_name_last_name(), vcard.nicknames[0])
             elif config.display == "formatted_name":
-                return"{} (Nickname: {})".format(vcard.formatted_name,
-                                                 vcard.nicknames[0])
-            else:
-                return "{} (Nickname: {})".format(
-                    vcard.get_last_name_first_name(), vcard.nicknames[0])
+                return "{} (Nickname: {})".format(vcard.formatted_name,
+                                                  vcard.nicknames[0])
+            return "{} (Nickname: {})".format(
+                vcard.get_last_name_first_name(), vcard.nicknames[0])
         else:
             if config.display == "first_name":
                 return vcard.get_first_name_last_name()
@@ -433,8 +432,8 @@ def get_special_field(vcard, field):
                     or email_dict.keys()
             # get first key in alphabetical order
             first_type = sorted(email_keys, key=lambda k: k[0].lower())[0]
-            return"{}: {}".format(first_type,
-                                  sorted(email_dict.get(first_type))[0])
+            return "{}: {}".format(first_type,
+                                   sorted(email_dict.get(first_type))[0])
     return ""
 
 

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -297,7 +297,7 @@ def list_address_books(address_books):
     print(helpers.pretty_print(table))
 
 
-def list_contacts(vcard_list):
+def list_contacts(vcard_list, fields=[]):
     selected_address_books = []
     for contact in vcard_list:
         if contact.address_book not in selected_address_books:
@@ -313,8 +313,19 @@ def list_contacts(vcard_list):
         table_header = ["Index", "Name", "Phone", "E-Mail", "Address book"]
     if config.show_uids:
         table_header.append("UID")
-        abook_collection = AddressBookCollection('short uids collection',
-                                                 selected_address_books)
+    if fields:
+        field = {
+            'index': "Index",
+            'name': "Name",
+            'phone': "Phone",
+            'email': "E-Mail",
+            'addressbook': "Address book",
+            'uid': "UID",
+        }
+        table_header = [field[x] for x in fields if x in field]
+
+    abook_collection = AddressBookCollection('short uids collection',
+                                             selected_address_books)
 
     table.append(table_header)
     # table body
@@ -350,7 +361,7 @@ def list_contacts(vcard_list):
                     break
             if not phone_keys:
                 phone_keys = [x for x in phone_dict if "pref" in x.lower()] \
-                             or phone_dict.keys()
+                    or phone_dict.keys()
             # get first key in alphabetical order
             first_type = sorted(phone_keys, key=lambda k: k[0].lower())[0]
             row.append("{}: {}".format(first_type,
@@ -369,7 +380,7 @@ def list_contacts(vcard_list):
                     break
             if not email_keys:
                 email_keys = [x for x in email_dict if "pref" in x.lower()] \
-                             or email_dict.keys()
+                    or email_dict.keys()
             # get first key in alphabetical order
             first_type = sorted(email_keys, key=lambda k: k[0].lower())[0]
             row.append("{}: {}".format(first_type,
@@ -378,7 +389,7 @@ def list_contacts(vcard_list):
             row.append("")
         if len(selected_address_books) > 1:
             row.append(vcard.address_book.name)
-        if config.show_uids:
+        if "UID" in table_header:
             if abook_collection.get_short_uid(vcard.uid):
                 row.append(abook_collection.get_short_uid(vcard.uid))
             else:
@@ -816,7 +827,8 @@ def phone_subcommand(search_terms, vcard_list, parsable):
                         # field and match against that.
                         if re.sub(r"\D", "", search_str) in re.sub(r"\D", "",
                                                                    number):
-                            matching_phone_number_list.append(phone_number_line)
+                            matching_phone_number_list.append(
+                                phone_number_line)
                 # collect all phone numbers in a different list as fallback
                 all_phone_numbers_list.append(phone_number_line)
     numbers = matching_phone_number_list or all_phone_numbers_list
@@ -961,7 +973,7 @@ def email_subcommand(search_terms, vcard_list, parsable, remove_first_line):
         sys.exit(1)
 
 
-def list_subcommand(vcard_list, parsable):
+def list_subcommand(vcard_list, parsable, fields):
     """Print a user friendly contacts table.
 
     :param vcard_list: the vcards to print
@@ -989,7 +1001,7 @@ def list_subcommand(vcard_list, parsable):
                                                 vcard.address_book.name]))
         print('\n'.join(contact_line_list))
     else:
-        list_contacts(vcard_list)
+        list_contacts(vcard_list, fields)
 
 
 def modify_subcommand(selected_vcard, input_from_stdin_or_file, open_editor,
@@ -1293,7 +1305,7 @@ def main(argv=sys.argv[1:]):
         email_subcommand(args.search_terms, vcard_list,
                          args.parsable, args.remove_first_line)
     elif args.action == "list":
-        list_subcommand(vcard_list, args.parsable)
+        list_subcommand(vcard_list, args.parsable, args.fields)
     elif args.action in ["show", "edit", "remove"]:
         selected_vcard = choose_vcard_from_list(
             "Select contact for {} action".format(args.action.title()),

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -66,7 +66,7 @@ class ListingCommands(unittest.TestCase):
         expected = [
             "Address book: foo",
             "Index    Name              Phone                "
-            "E-Mail                    UID",
+            "Email                     Uid",
             "1        second contact    voice: 0123456789    "
             "home: user@example.com    testuid1",
             "2        text birthday                          "
@@ -146,7 +146,7 @@ class ListingCommands(unittest.TestCase):
         expected = [
             "Address book: foo",
             "Index    Name              Phone                "
-            "E-Mail                    UID",
+            "Email                     Uid",
             "1        second contact    voice: 0123456789    "
             "home: user@example.com    testuid1"]
         self.assertListEqual(text1, expected)
@@ -162,7 +162,7 @@ class ListingCommands(unittest.TestCase):
         expected = [
             "Address book: foo",
             "Index    Name              Phone                "
-            "E-Mail                    UID",
+            "Email                     Uid",
             "1        second contact    voice: 0123456789    "
             "home: user@example.com    testuid1"]
         self.assertListEqual(text1, expected)
@@ -184,8 +184,8 @@ class ListingCommands2(unittest.TestCase):
         text = [line.strip() for line in stdout.getvalue().splitlines()]
         expect = [
             "Address book: tmp",
-            "Index    Name       Phone             E-Mail    UID",
-            "1        bug 195    cell: 67545678              b"]
+            "Index    Name       Phone             Email    Uid",
+            "1        bug 195    cell: 67545678             b"]
         self.assertListEqual(text, expect)
 
     def test_list_bug_243_part_1(self):
@@ -197,7 +197,7 @@ class ListingCommands2(unittest.TestCase):
         expect = [
             "Address book: tmp",
             "Index    Name                     Phone    "
-            "E-Mail                       UID",
+            "Email                        Uid",
             "1        contact with category             "
             "internet: foo@example.org    c",
         ]

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -75,6 +75,16 @@ class ListingCommands(unittest.TestCase):
             "                          testuid2"]
         self.assertListEqual(text, expected)
 
+    def test_ls_fields_like_email(self):
+        with mock_stdout() as stdout:
+            khard.main(['ls', '-p', '-F', 'email,formatted_name'])
+        text = [l.strip() for l in stdout.getvalue().splitlines()]
+        expected = [
+            "E-Mail\tName",
+            "user@example.com\tsecond contact",
+        ]
+        self.assertListEqual(text, expected)
+
     @mock.patch.dict('os.environ', LC_ALL='C')
     def test_simple_bdays_without_options(self):
         with mock_stdout() as stdout:

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -77,11 +77,12 @@ class ListingCommands(unittest.TestCase):
 
     def test_ls_fields_like_email(self):
         with mock_stdout() as stdout:
-            khard.main(['ls', '-p', '-F', 'email,formatted_name'])
-        text = [l.strip() for l in stdout.getvalue().splitlines()]
+            khard.main(['ls', '-p', '-F', 'emails.home.0,name'])
+        text = stdout.getvalue().splitlines()
         expected = [
-            "E-Mail\tName",
             "user@example.com\tsecond contact",
+            "\ttext birthday",
+            "\tthird contact",
         ]
         self.assertListEqual(text, expected)
 


### PR DESCRIPTION
https://github.com/scheibler/khard/issues/179#issuecomment-576060333

Things you can do with this

* `python3 -m khard ls -F name,birthday` (like `khard bdays`, but it doesn't sort, doesn't exclude missing birthdays, and outputs in a different format)
* `python3 -m khard ls -pF emails.home.0,name` (shows first home email address for each user)
* `python3 -m  khard ls --fields phone_numbers.cell.0,phone_numbers` (shows first cell number, and all phone numbers in python format)
* `python3 -m khard ls -p -F Name,post_addresses.home.0.region,post_addresses.home.0.code` (name, state and zip code)

The list of properties can be seen with

`grep '@property' -A1 khard/carddav_object.py`

(Additional fields can easily be added by making them attributes in carddav_object.py)

For backwards compatibility with previous usage, the additional fields are defined:
* index (counts 1,2,3,...)
* name (formats name as desired)
* ~~address_book~~
* phone
* email
*  uid (prints minimized when not using --parsable)
* ~~uid_short~~