### PR TITLE
Refactor query representation

### DIFF
--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -76,13 +76,13 @@ class AddressBook(metaclass=abc.ABCMeta):
         for contact in self.contacts.values():
             # search in all contact fields
             contact_details = contact.pretty().lower()
-            if contact.match(contact_details, query):
+            if query.match(contact_details):
                 yield contact
             else:
                 # find phone numbers with special chars like /
                 clean_contact_details = re.sub("[^a-zA-Z0-9\n]", "",
                                                contact_details)
-                if contact.match(clean_contact_details, query):
+                if query.match(clean_contact_details):
                     yield contact
 
     def _search_names(self, query: Query) -> Generator[
@@ -94,7 +94,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         """
         for contact in self.contacts.values():
             # only search in contact name
-            if contact.match(contact.formatted_name, query):
+            if query.match(contact.formatted_name):
                 yield contact
 
     def _search_uid(self, query: str) -> Generator[

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -10,10 +10,10 @@ from typing import cast, Dict, Generator, Iterator, List, Optional, Union
 import vobject.base
 
 from . import carddav_object
+from.query import AnyQuery, Query
 
 
 logger = logging.getLogger(__name__)
-Query = Union[None, str, List[str], List[List[str]]]
 
 
 class AddressBookParseError(Exception):
@@ -66,7 +66,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         """
         return len(os.path.commonprefix((uid1, uid2)))
 
-    def _search_all(self, query: Union[None, str, List[str]]) -> Generator[
+    def _search_all(self, query: Query) -> Generator[
             "carddav_object.CarddavObject", None, None]:
         """Search in all fields for contacts matching query.
 
@@ -85,8 +85,8 @@ class AddressBook(metaclass=abc.ABCMeta):
                 if contact.match(clean_contact_details, query):
                     yield contact
 
-    def _search_names(self, query) -> Generator["carddav_object.CarddavObject",
-                                                None, None]:
+    def _search_names(self, query: Query) -> Generator[
+            "carddav_object.CarddavObject", None, None]:
         """Search in the name filed for contacts matching query.
 
         :param query: the query to search for
@@ -115,8 +115,8 @@ class AddressBook(metaclass=abc.ABCMeta):
                 if uid.startswith(query):
                     yield self.contacts[uid]
 
-    def search(self, query: Union[None, str, List[str]], method: str = "all"
-               ) -> Generator["carddav_object.CarddavObject", None, None]:
+    def search(self, query: Query, method: str = "all") -> Generator[
+            "carddav_object.CarddavObject", None, None]:
         """Search this address book for contacts matching the query.
 
         The method can be one of "all", "name" and "uid".  The backend for this
@@ -138,8 +138,8 @@ class AddressBook(metaclass=abc.ABCMeta):
         raise ValueError(
             'Only the search methods "all", "name" and "uid" are supported.')
 
-    def get_short_uid_dict(self, query: Optional[str] = None
-                           ) -> Dict[str, "carddav_object.CarddavObject"]:
+    def get_short_uid_dict(self, query: Query = AnyQuery()) -> Dict[
+            str, "carddav_object.CarddavObject"]:
         """Create a dictionary of shortend UIDs for all contacts.
 
         All arguments are only used if the address book is not yet initialized
@@ -150,7 +150,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         """
         if self._short_uids is None:
             if not self._loaded:
-                self.load([query] if query is not None else None)
+                self.load(query)
             if not self.contacts:
                 self._short_uids = {}
             elif len(self.contacts) == 1:
@@ -189,7 +189,7 @@ class AddressBook(metaclass=abc.ABCMeta):
         return ""
 
     @abc.abstractmethod
-    def load(self, query: Query = None) -> None:
+    def load(self, query: Query = AnyQuery()) -> None:
         """Load the vCards from the backing store.
 
         If a query is given loading is limited to entries which match the
@@ -227,14 +227,14 @@ class VdirAddressBook(AddressBook):
         self._skip = skip
         super().__init__(name)
 
-    def load(self, query: Query = None,
+    def load(self, query: Query = AnyQuery(),
              search_in_source_files: bool = False) -> None:
         """Load all vcard files in this address book from disk.
 
         If a search string is given only files which contents match that will
         be loaded.
 
-        :param query: a regular expression to limit the results
+        :param query: query to limit the vcards that should be parsed
         :param search_in_source_files: apply search regexp directly on the .vcf
             files to speed up parsing (less accurate)
         :throws: AddressBookParseError
@@ -246,7 +246,8 @@ class VdirAddressBook(AddressBook):
         for filename in glob.glob(os.path.join(self.path, "*.vcf")):
             try:
                 card = carddav_object.CarddavObject.from_file(
-                    self, filename, query if search_in_source_files else None,
+                    self, filename,
+                    query if search_in_source_files else AnyQuery(),
                     self._private_objects, self._localize_dates)
                 if card is None:
                     continue
@@ -297,12 +298,12 @@ class AddressBookCollection(AddressBook):
         super().__init__(name)
         self._abooks = {ab.name: ab for ab in abooks}
 
-    def load(self, query: Query = None) -> None:
+    def load(self, query: Query = AnyQuery()) -> None:
         """Load the wrapped address books with the given parameters
 
         All parameters will be handed to VdirAddressBook.load.
 
-        :param query: a regular expression to limit the results
+        :param query: a query to limit the vcards that should be parsed
         :throws: AddressBookParseError
         """
         if self._loaded:

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -14,7 +14,7 @@ import os
 import re
 import sys
 import time
-from typing import cast, Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from atomicwrites import atomic_write
 from ruamel import yaml

--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -23,10 +23,10 @@ import vobject
 from . import address_book
 from . import helpers
 from .object_type import ObjectType
+from .query import Query
 
 
 logger = logging.getLogger(__name__)
-Query = Union[None, str, List[str], List[List[str]]]
 
 
 def convert_to_vcard(name: str, value: Union[str, List[str]],
@@ -1554,28 +1554,7 @@ class CarddavObject(YAMLEditable):
         :param string: the string which to check
         :param query:
         """
-        def match_str(q: str, s: str) -> bool:
-            return q.lower() in s
-
-        def match_list1(q: List[str], s: str) -> bool:
-            return all(match_str(qq, s) for qq in q)
-
-        def match_list2(q: List[List[str]], s: str) -> bool:
-            return any(match_list1(qq, s) for qq in q)
-
-        logger.debug('match: %s', [string, query])
-
-        if query is None:
-            return True
-        string = string.lower()
-        if isinstance(query, str):
-            return match_str(query, string)
-        # now query can only be list(str) or list(list(str))
-        if not query:
-            return False
-        if isinstance(query[0], str):
-            return match_list1(cast(List[str], query), string)
-        return match_list2(cast(List[List[str]], query), string)
+        return query.match(string)
 
     ######################################
     # overwrite some default class methods

--- a/khard/cli.py
+++ b/khard/cli.py
@@ -158,6 +158,7 @@ def create_parsers() -> Tuple[argparse.ArgumentParser,
         help="select contact by uid")
     default_search_parser.add_argument(
         "search_terms", nargs="*", metavar="search terms", type=TermQuery,
+        default=[],
         help="search in all fields to find matching contact")
     merge_search_parser = argparse.ArgumentParser(add_help=False)
     merge_search_parser.add_argument(
@@ -179,6 +180,7 @@ def create_parsers() -> Tuple[argparse.ArgumentParser,
         help="select target contact by uid")
     merge_search_parser.add_argument(
         "source_search_terms", nargs="*", metavar="source", type=TermQuery,
+        default=[],
         help="search in all fields to find matching source contact")
 
     # create subparsers for actions
@@ -422,10 +424,10 @@ def parse_args(argv: List[str]) -> Tuple[argparse.Namespace, Config]:
         parser.error("You can not give arbitrary search terms and --uid at the"
                      " same time.")
     # Build conjunctive queries
-    if "source_search_terms" in args and args.source_search_terms:
+    if "source_search_terms" in args:
         args.source_search_terms = reduce(operator.and_,
                                           args.source_search_terms, AnyQuery())
-    if "search_terms" in args and args.search_terms:
+    if "search_terms" in args:
         args.search_terms = reduce(operator.and_, args.search_terms,
                                    AnyQuery())
 

--- a/khard/cli.py
+++ b/khard/cli.py
@@ -1,9 +1,7 @@
 """Command line parsing and configuration logic for khard"""
 
 import argparse
-from functools import reduce
 import logging
-import operator
 import sys
 from typing import List, Tuple
 
@@ -429,11 +427,10 @@ def parse_args(argv: List[str]) -> Tuple[argparse.Namespace, Config]:
     # Build conjunctive queries.  If uid was given the list of search terms
     # will be empty.  If no uid was given it will be None.
     if "source_search_terms" in args:
-        args.source_search_terms = reduce(
-            operator.and_, args.source_search_terms, args.uid or AnyQuery())
+        args.source_search_terms = AndQuery.reduce(args.source_search_terms,
+                                                   args.uid)
     if "search_terms" in args:
-        args.search_terms = reduce(operator.and_, args.search_terms,
-                                   args.uid or AnyQuery())
+        args.search_terms = AndQuery.reduce(args.search_terms, args.uid)
     if "target_contact" in args:
         # Only one of target_contact or target_uid can be set.
         args.target_contact = args.target_contact or args.target_uid \

--- a/khard/config.py
+++ b/khard/config.py
@@ -14,6 +14,7 @@ import validate
 from .actions import Actions
 from .address_book import AddressBookCollection, AddressBookNameError, \
     VdirAddressBook
+from .query import Query
 
 
 logger = logging.getLogger(__name__)
@@ -175,12 +176,12 @@ class Config:
         except IOError as err:
             raise ConfigError(str(err))
 
-    def get_address_books(self, names: Iterable[str], queries: Dict
+    def get_address_books(self, names: Iterable[str], queries: Dict[str, Query]
                           ) -> AddressBookCollection:
         """Load all address books with the given names.
 
         :param names: the address books to load
-        :param dict queries: a mapping of address book names to search queries
+        :param queries: a mapping of address book names to search queries
         :returns: the loaded address books
         """
         all_names = {str(book) for book in self.abooks}

--- a/khard/config.py
+++ b/khard/config.py
@@ -197,7 +197,7 @@ class Config:
         # We can not use AddressBookCollection.load here because we want to
         # select the collection based on the address book.
         for abook in collection:
-            abook.load(queries[abook.name], self.search_in_source_files) # type: ignore
+            abook.load(queries[abook.name], self.search_in_source_files)
         return collection
 
     def merge(self, other: Union[configobj.ConfigObj, Dict]) -> None:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -6,7 +6,6 @@ from email import message_from_string
 from email.policy import SMTP as SMTP_POLICY
 import logging
 import os
-import re
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
@@ -736,17 +735,6 @@ def phone_subcommand(search_terms: Query, vcard_list: List[CarddavObject],
                 if search_terms.match("{}\n{}".format(line_formatted,
                                                       line_parsable)):
                     matching_phone_number_list.append(phone_number_line)
-                else:
-                    search_str = ''.join(search_terms)
-                    if len(re.sub(r"\D", "", search_str)) >= 3:
-                        # The user likely searches for a phone number cause the
-                        # search string contains at least three digits.  So we
-                        # remove all non-digit chars from the phone number
-                        # field and match against that.
-                        if re.sub(r"\D", "", search_str) in re.sub(r"\D", "",
-                                                                   number):
-                            matching_phone_number_list.append(
-                                phone_number_line)
                 # collect all phone numbers in a different list as fallback
                 all_phone_numbers_list.append(phone_number_line)
     numbers = matching_phone_number_list or all_phone_numbers_list

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
-from typing import cast, Iterable, List, Optional, TypeVar, Union
+from typing import cast, Dict, Iterable, List, Optional, TypeVar, Union
 
 from unidecode import unidecode
 
@@ -21,6 +21,7 @@ from .carddav_object import CarddavObject
 from . import cli
 from .config import Config
 from .formatter import Formatter
+from .query import AndQuery, AnyQuery, NullQuery, OrQuery, Query
 from .version import version as khard_version
 
 
@@ -453,62 +454,41 @@ def get_contacts(address_book: Union[VdirAddressBook, AddressBookCollection],
                      '"formatted_name" not {}.'.format(sort))
 
 
-def prepare_search_queries(args):
+def prepare_search_queries(args: Namespace) -> Dict[str, Query]:
     """Prepare the search query string from the given command line args.
 
     Each address book can get a search query string to filter vcards befor
     loading them.  Depending on the question if the address book is used for
-    source or target searches different regexes have to be combined into one
-    search string.
+    source or target searches different queries have to be combined.
 
     :param args: the parsed command line
-    :type args: argparse.Namespace
-    :returns: a dict mapping abook names to their loading queries, if the query
-        is None it means that all cards should be loaded
-    :rtype: dict(str:list(list(str)) or None)
+    :returns: a dict mapping abook names to their loading queries
     """
     # get all possible search queries for address book parsing
-    source_queries = []
-    target_queries = []
-    if "source_search_terms" in args and args.source_search_terms:
-        processed_terms = [x.lower() for x in args.source_search_terms]
-        source_queries.extend(processed_terms)
-        args.source_search_terms = processed_terms
-    if "search_terms" in args and args.search_terms:
-        processed_terms = [x.lower() for x in args.search_terms]
-        source_queries.extend(processed_terms)
-        args.search_terms = processed_terms
-    if "target_contact" in args and args.target_contact:
-        processed_term = args.target_contact.lower()
-        target_queries.append(processed_term)
-        args.target_contact = processed_term
-    if "uid" in args and args.uid:
-        source_queries.append(args.uid.lower())
-    if "target_uid" in args and args.target_uid:
-        target_queries.append(args.target_uid.lower())
-    # None means that no query is given and hence all contacts should be
-    # searched.
-    source_queries = source_queries or None
-    target_queries = target_queries or None
-    logger.debug('Created source query: %s', source_queries)
-    logger.debug('Created target query: %s', target_queries)
+    source_queries: List[Query] = []
+    target_queries: List[Query] = []
+    if "source_search_terms" in args:
+        source_queries.append(args.source_search_terms)
+    if "search_terms" in args:
+        source_queries.append(args.search_terms)
+    if "target_contact" in args:
+        target_queries.append(args.target_contact)
+    source_query = AndQuery.reduce(source_queries)
+    target_query = AndQuery.reduce(target_queries)
+    logger.debug('Created source query: %s', source_query)
+    logger.debug('Created target query: %s', target_query)
     # Get all possible search queries for address book parsing, always
     # depending on the fact if the address book is used to find source or
     # target contacts or both.
-    queries = {abook.name: [] for abook in config.abooks}
+    queries: Dict[str, List[Query]] = {abook.name: [] for abook in config.abooks}
     for name in queries:
         if "addressbook" in args and name in args.addressbook:
-            queries[name].append(source_queries)
+            queries[name].append(source_query)
         if "target_addressbook" in args and name in args.target_addressbook:
-            queries[name].append(target_queries)
-        # If None is included in the search queries of an address book it means
-        # that either no source or target query was given and this address book
-        # is affected by this.  All contacts should be loaded from that address
-        # book.
-        if None in queries[name]:
-            queries[name] = None
+            queries[name].append(target_query)
+    queries2: Dict[str, Query] = {n: OrQuery.reduce(q) for n, q in queries.items()}
     logger.debug('Created query: %s', queries)
-    return queries
+    return queries2
 
 
 def generate_contact_list(args: Namespace) -> List[CarddavObject]:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -21,7 +21,7 @@ from .carddav_object import CarddavObject
 from . import cli
 from .config import Config
 from .formatter import Formatter
-from .query import AndQuery, OrQuery, Query, TermQuery
+from .query import AndQuery, AnyQuery, OrQuery, Query, TermQuery
 from .version import version as khard_version
 
 
@@ -521,19 +521,14 @@ def generate_contact_list(args: Namespace) -> List[CarddavObject]:
         # contact.
         if "source_search_terms" in args:
             # exception for merge command
-            if args.source_search_terms:
-                args.search_terms = args.source_search_terms
-            else:
-                args.search_terms = None
+            args.search_terms = args.source_search_terms or AnyQuery()
         elif "search_terms" in args:
-            if args.search_terms:
-                args.search_terms = args.search_terms
-            else:
-                args.search_terms = None
+            if not args.search_terms:
+                args.search_terms = AnyQuery()
         else:
             # If no search terms where given on the command line we match
             # everything with the empty search pattern.
-            args.search_terms = None
+            args.search_terms = AnyQuery()
         logger.debug("args.search_terms=%s", args.search_terms)
         vcard_list = get_contact_list_by_user_selection(
             args.addressbook, args.search_terms,

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -21,7 +21,7 @@ from .carddav_object import CarddavObject
 from . import cli
 from .config import Config
 from .formatter import Formatter
-from .query import AndQuery, AnyQuery, NullQuery, OrQuery, Query
+from .query import AndQuery, OrQuery, Query, TermQuery
 from .version import version as khard_version
 
 
@@ -397,7 +397,7 @@ def choose_vcard_from_list(header_string: str, vcard_list: List[CarddavObject],
 
 def get_contact_list_by_user_selection(
         address_books: Union[VdirAddressBook, AddressBookCollection],
-        search: Optional[List[str]], strict_search: bool) -> List[CarddavObject]:
+        search: Query, strict_search: bool) -> List[CarddavObject]:
     """returns a list of CarddavObject objects
     :param address_books: selected address books
     :param search: filter contact list
@@ -410,9 +410,9 @@ def get_contact_list_by_user_selection(
 
 
 def get_contacts(address_book: Union[VdirAddressBook, AddressBookCollection],
-                 query: Optional[List[str]], method: str = "all",
-                 reverse: bool = False, group: bool = False,
-                 sort: str = "first_name") -> List[CarddavObject]:
+                 query: Query, method: str = "all", reverse: bool = False,
+                 group: bool = False, sort: str = "first_name") -> List[
+                    CarddavObject]:
     """Get a list of contacts from one or more address books.
 
     :param address_book: the address book to search
@@ -709,7 +709,7 @@ def birthdays_subcommand(vcard_list: List[CarddavObject], parsable: bool
         sys.exit(1)
 
 
-def phone_subcommand(search_terms: List[str], vcard_list: List[CarddavObject],
+def phone_subcommand(search_terms: Query, vcard_list: List[CarddavObject],
                      parsable: bool) -> None:
     """Print a phone application friendly contact table.
 
@@ -767,7 +767,7 @@ def phone_subcommand(search_terms: List[str], vcard_list: List[CarddavObject],
         sys.exit(1)
 
 
-def post_address_subcommand(search_terms: List[str],
+def post_address_subcommand(search_terms: Query,
                             vcard_list: List[CarddavObject], parsable: bool
                             ) -> None:
     """Print a contact table. with all postal / mailing addresses
@@ -820,7 +820,7 @@ def post_address_subcommand(search_terms: List[str],
         sys.exit(1)
 
 
-def email_subcommand(search_terms: List[str], vcard_list: List[CarddavObject],
+def email_subcommand(search_terms: Query, vcard_list: List[CarddavObject],
                      parsable: bool, remove_first_line: bool) -> None:
     """Print a mail client friendly contacts table that is compatible with the
     default format used by mutt.
@@ -1056,7 +1056,7 @@ def copy_or_move_subcommand(action: str, vcard_list: List[CarddavObject],
     target_vcard = choose_vcard_from_list(
         "Select target contact to overwrite (or None to add a new entry)",
         get_contact_list_by_user_selection(
-            target_abook, [source_vcard.formatted_name], True), True)
+            target_abook, TermQuery(source_vcard.formatted_name), True), True)
     # If the target contact doesn't exist, move or copy the source contact into
     # the target address book without further questions.
     if target_vcard is None:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -733,9 +733,8 @@ def phone_subcommand(search_terms: Query, vcard_list: List[CarddavObject],
                 else:
                     # else: start with name
                     phone_number_line = line_formatted
-                if CarddavObject.match(
-                        "{}\n{}".format(line_formatted, line_parsable),
-                        search_terms):
+                if search_terms.match("{}\n{}".format(line_formatted,
+                                                      line_parsable)):
                     matching_phone_number_list.append(phone_number_line)
                 else:
                     search_str = ''.join(search_terms)
@@ -797,9 +796,7 @@ def post_address_subcommand(search_terms: Query,
                         "\t".join([name, type, address]))
         # add to matching and all post address lists
         for post_address_line in post_address_line_list:
-            if CarddavObject.match(
-                    "{0}\n{0}".format(post_address_line),
-                    search_terms):
+            if search_terms.match("{0}\n{0}".format(post_address_line)):
                 matching_post_address_list.append(post_address_line)
             # collect all post addresses in a different list as fallback
             all_post_address_list.append(post_address_line)
@@ -854,9 +851,8 @@ def email_subcommand(search_terms: Query, vcard_list: List[CarddavObject],
                 else:
                     # else: start with name
                     email_address_line = line_formatted
-                if CarddavObject.match(
-                        "{}\n{}".format(line_formatted, line_parsable),
-                        search_terms):
+                if search_terms.match("{}\n{}".format(line_formatted,
+                                                      line_parsable)):
                     matching_email_address_list.append(email_address_line)
                 # collect all email addresses in a different list as fallback
                 all_email_address_list.append(email_address_line)

--- a/khard/query.py
+++ b/khard/query.py
@@ -1,7 +1,9 @@
 """Queries to match against contacts"""
 
 import abc
-from typing import List, Union
+from functools import reduce
+from operator import and_, or_
+from typing import List, Optional, Union
 
 from .carddav_object import CarddavObject
 
@@ -120,6 +122,10 @@ class AndQuery(Query):
     def __hash__(self) -> int:
         return hash((AndQuery, frozenset(self._queries)))
 
+    @staticmethod
+    def reduce(queries: List[Query], start: Optional[Query] = None) -> Query:
+        return reduce(and_, queries, start or AnyQuery())
+
 
 class OrQuery(Query):
 
@@ -135,3 +141,7 @@ class OrQuery(Query):
 
     def __hash__(self) -> int:
         return hash((OrQuery, frozenset(self._queries)))
+
+    @staticmethod
+    def reduce(queries: List[Query], start: Optional[Query] = None) -> Query:
+        return reduce(or_, queries, start or NullQuery())

--- a/khard/query.py
+++ b/khard/query.py
@@ -32,8 +32,8 @@ class TermQuery(Query):
 
 class AndQuery(Query):
 
-    def __init__(self, *queries: Query) -> None:
-        self._queries = queries
+    def __init__(self, first: Query, second: Query, *queries: Query) -> None:
+        self._queries = (first, second, *queries)
 
     def match(self, thing: Union[str, List[str]]) -> bool:
         return all(q.match(thing) for q in self._queries)
@@ -41,8 +41,8 @@ class AndQuery(Query):
 
 class OrQuery(Query):
 
-    def __init__(self, *queries: Query) -> None:
-        self._queries = queries
+    def __init__(self, first: Query, second: Query, *queries: Query) -> None:
+        self._queries = (first, second, *queries)
 
     def match(self, thing: Union[str, List[str]]) -> bool:
         return any(q.match(thing) for q in self._queries)

--- a/khard/query.py
+++ b/khard/query.py
@@ -1,0 +1,48 @@
+"""Queries to match against contacts"""
+
+import abc
+from typing import List, Union
+
+
+class Query(metaclass=abc.ABCMeta):
+
+    """A query to match against strings, lists of strings and CarddavObjects"""
+
+    @abc.abstractmethod
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        """Match the self query against the given thing"""
+
+
+class AnyQuery(Query):
+
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        return True
+
+
+class TermQuery(Query):
+
+    def __init__(self, term: str) -> None:
+        self._term = term.lower()
+
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        if isinstance(thing, str):
+            return self._term in thing.lower()
+        return any(self.match(t) for t in thing)
+
+
+class AndQuery(Query):
+
+    def __init__(self, *queries: Query) -> None:
+        self._queries = queries
+
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        return all(q.match(thing) for q in self._queries)
+
+
+class OrQuery(Query):
+
+    def __init__(self, *queries: Query) -> None:
+        self._queries = queries
+
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        return any(q.match(thing) for q in self._queries)

--- a/khard/query.py
+++ b/khard/query.py
@@ -3,6 +3,8 @@
 import abc
 from typing import List, Union
 
+from .carddav_object import CarddavObject
+
 
 class Query(metaclass=abc.ABCMeta):
 
@@ -66,6 +68,17 @@ class TermQuery(Query):
         if isinstance(thing, str):
             return self._term in thing.lower()
         return any(self.match(t) for t in thing)
+
+
+class FieldQuery(TermQuery):
+
+    def __init__(self, field: str, value: str) -> None:
+        self._field = field
+        super().__init__(value)
+
+    def match(self, thing: CarddavObject) -> bool:
+        return hasattr(thing, self._field) \
+            and super().match(getattr(thing, self._field))
 
 
 class AndQuery(Query):

--- a/khard/query.py
+++ b/khard/query.py
@@ -13,6 +13,12 @@ class Query(metaclass=abc.ABCMeta):
         """Match the self query against the given thing"""
 
 
+class NullQuery(Query):
+
+    def match(self, thing: Union[str, List[str]]) -> bool:
+        return False
+
+
 class AnyQuery(Query):
 
     def match(self, thing: Union[str, List[str]]) -> bool:

--- a/khard/query.py
+++ b/khard/query.py
@@ -12,6 +12,38 @@ class Query(metaclass=abc.ABCMeta):
     def match(self, thing: Union[str, List[str]]) -> bool:
         """Match the self query against the given thing"""
 
+    def __and__(self, other: "Query") -> "Query":
+        """Combine two queries with AND"""
+        if isinstance(self, NullQuery) or isinstance(other, NullQuery):
+            return NullQuery()
+        if isinstance(self, AnyQuery):
+            return other
+        if isinstance(other, AnyQuery):
+            return self
+        if isinstance(self, AndQuery) and isinstance(other, AndQuery):
+            return AndQuery(*self._queries, *other._queries)
+        if isinstance(self, AndQuery):
+            return AndQuery(*self._queries, other)
+        if isinstance(other, AndQuery):
+            return AndQuery(self, *other._queries)
+        return AndQuery(self, other)
+
+    def __or__(self, other: "Query") -> "Query":
+        """Combine two queries with OR"""
+        if isinstance(self, AnyQuery) or isinstance(other, AnyQuery):
+            return AnyQuery()
+        if isinstance(self, NullQuery):
+            return other
+        if isinstance(other, NullQuery):
+            return self
+        if isinstance(self, OrQuery) and isinstance(other, OrQuery):
+            return OrQuery(*self._queries, *other._queries)
+        if isinstance(self, OrQuery):
+            return OrQuery(*self._queries, other)
+        if isinstance(other, OrQuery):
+            return OrQuery(self, *other._queries)
+        return OrQuery(self, other)
+
 
 class NullQuery(Query):
 

--- a/khard/query.py
+++ b/khard/query.py
@@ -5,7 +5,7 @@ from functools import reduce
 from operator import and_, or_
 from typing import List, Optional, Union
 
-from .carddav_object import CarddavObject
+from . import carddav_object
 
 
 class Query(metaclass=abc.ABCMeta):
@@ -95,7 +95,7 @@ class FieldQuery(TermQuery):
         self._field = field
         super().__init__(value)
 
-    def match(self, thing: CarddavObject) -> bool:
+    def match(self, thing: "carddav_object.CarddavObject") -> bool:
         return hasattr(thing, self._field) \
             and super().match(getattr(thing, self._field))
 

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -5,6 +5,7 @@ import unittest
 from unittest import mock
 
 from khard import address_book
+from khard.query import TermQuery
 
 
 class _AddressBook(address_book.AddressBook):
@@ -90,7 +91,7 @@ class VcardAdressBookLoad(unittest.TestCase):
 
     def test_search_in_source_files_only_loads_matching_cards(self):
         abook = address_book.VdirAddressBook('test', 'test/fixture/test.abook')
-        abook.load(query='second', search_in_source_files=True)
+        abook.load(query=TermQuery('second'), search_in_source_files=True)
         self.assertEqual(len(abook.contacts), 1)
 
     def test_loading_unparsable_vcard_fails(self):

--- a/test/test_carddav_object.py
+++ b/test/test_carddav_object.py
@@ -35,7 +35,6 @@ class CarddavObjectFormatDateObject(unittest.TestCase):
 class AltIds(unittest.TestCase):
 
     def test_altids_are_read(self):
-        card = CarddavObject.from_file(None, 'test/fixture/vcards/altid.vcf',
-                                       None)
+        card = CarddavObject.from_file(None, 'test/fixture/vcards/altid.vcf')
         expected = 'one representation'
         self.assertEqual(expected, card.get_first_name_last_name())

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the cli module"""
 
 import unittest
+from unittest import mock
 
 from khard import cli
 from khard import query
@@ -8,6 +9,7 @@ from khard import query
 from .helpers import mock_stream
 
 
+@mock.patch.dict('os.environ', KHARD_CONFIG='test/fixture/minimal.conf')
 class TestParseArgs(unittest.TestCase):
 
     foo = query.TermQuery("foo")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,11 +5,14 @@ import unittest
 from khard import cli
 from khard import query
 
+from .helpers import mock_stream
+
 
 class TestParseArgs(unittest.TestCase):
 
     foo = query.TermQuery("foo")
     bar = query.TermQuery("bar")
+    baz = query.TermQuery("baz")
     uid = query.FieldQuery("uid", "foo")
 
     def test_normal_search_terms_create_term_queries(self):
@@ -29,3 +32,25 @@ class TestParseArgs(unittest.TestCase):
         args, _config = cli.parse_args(['list', 'foo', 'bar'])
         actual = args.search_terms
         self.assertEqual(expected, actual)
+
+    def test_no_search_terms_create_an_any_query(self):
+        expected = query.AnyQuery()
+        args, _config = cli.parse_args(['list'])
+        actual = args.search_terms
+        self.assertEqual(expected, actual)
+
+    def test_target_search_terms_are_typed(self):
+        args, _config = cli.parse_args(['merge', '--target=foo', 'bar'])
+        self.assertEqual(self.foo, args.target_contact)
+        self.assertEqual(self.bar, args.source_search_terms)
+
+    def test_second_target_search_term_overrides_first(self):
+        args, _config = cli.parse_args(['merge', '--target=foo',
+                                        '--target=bar', 'baz'])
+        self.assertEqual(self.bar, args.target_contact)
+        self.assertEqual(self.baz, args.source_search_terms)
+
+    def test_uid_and_free_search_terms_produce_a_conflict(self):
+        with self.assertRaises(SystemExit):
+            with mock_stream("stderr"):  # just silence stderr
+                cli.parse_args(['list', '--uid=foo', 'bar'])

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,0 +1,31 @@
+"""Tests for the cli module"""
+
+import unittest
+
+from khard import cli
+from khard import query
+
+
+class TestParseArgs(unittest.TestCase):
+
+    foo = query.TermQuery("foo")
+    bar = query.TermQuery("bar")
+    uid = query.FieldQuery("uid", "foo")
+
+    def test_normal_search_terms_create_term_queries(self):
+        expected = self.foo
+        args, _config = cli.parse_args(['list', 'foo'])
+        actual = args.search_terms
+        self.assertEqual(expected, actual)
+
+    def test_uid_options_create_uid_queries(self):
+        expected = self.uid
+        args, _config = cli.parse_args(['list', '--uid=foo'])
+        actual = args.uid
+        self.assertEqual(expected, actual)
+
+    def test_multible_search_terms_generate_and_queries(self):
+        expected = query.AndQuery(self.foo, self.bar)
+        args, _config = cli.parse_args(['list', 'foo', 'bar'])
+        actual = args.search_terms
+        self.assertEqual(expected, actual)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -24,7 +24,7 @@ class TestParseArgs(unittest.TestCase):
     def test_uid_options_create_uid_queries(self):
         expected = self.uid
         args, _config = cli.parse_args(['list', '--uid=foo'])
-        actual = args.uid
+        actual = args.search_terms
         self.assertEqual(expected, actual)
 
     def test_multible_search_terms_generate_and_queries(self):
@@ -50,7 +50,28 @@ class TestParseArgs(unittest.TestCase):
         self.assertEqual(self.bar, args.target_contact)
         self.assertEqual(self.baz, args.source_search_terms)
 
+    def test_target_uid_option_creates_uid_queries(self):
+        args, _config = cli.parse_args(['merge', '--target-uid=foo', 'bar'])
+        self.assertEqual(self.uid, args.target_contact)
+        self.assertEqual(self.bar, args.source_search_terms)
+
+    def test_uid_option_is_combined_with_search_terms_for_merge_command(self):
+        args, _config = cli.parse_args(['merge', '--uid=foo', '--target=bar'])
+        self.assertEqual(self.uid, args.source_search_terms)
+        self.assertEqual(self.bar, args.target_contact)
+
     def test_uid_and_free_search_terms_produce_a_conflict(self):
         with self.assertRaises(SystemExit):
             with mock_stream("stderr"):  # just silence stderr
                 cli.parse_args(['list', '--uid=foo', 'bar'])
+
+    def test_target_uid_and_free_target_search_terms_produce_a_conflict(self):
+        with self.assertRaises(SystemExit):
+            with mock_stream("stderr"):  # just silence stderr
+                cli.parse_args(['merge', '--target-uid=foo', '--target=bar'])
+
+    def test_no_target_specification_results_in_an_any_query(self):
+        expected = query.AnyQuery()
+        args, _config = cli.parse_args(['merge'])
+        actual = args.target_contact
+        self.assertEqual(expected, actual)

--- a/test/test_khard.py
+++ b/test/test_khard.py
@@ -1,0 +1,46 @@
+"""Unittests for the khard module"""
+
+from argparse import Namespace
+import unittest
+from unittest import mock
+
+from khard import khard
+from khard import query
+
+
+class TestSearchQueryPreparation(unittest.TestCase):
+
+    foo = query.TermQuery("foo")
+    bar = query.TermQuery("bar")
+
+    def setUp(self):
+        # Set the uninitialized global variable in the khard module to make it
+        # mockable. See https://stackoverflow.com/questions/61193676
+        khard.config = mock.Mock()
+
+    @staticmethod
+    def _make_abook(name):
+        abook = mock.Mock()
+        abook.name = name
+        return abook
+
+    @classmethod
+    def _run(cls, **kwargs):
+        with mock.patch("khard.khard.config.abooks",
+                        [cls._make_abook(name)
+                         for name in ["foo", "bar", "baz"]]):
+            return khard.prepare_search_queries(Namespace(**kwargs))
+
+    def test_queries_for_the_same_address_book_are_joind_by_disjunction(self):
+        expected = self.foo | self.bar
+        prepared = self._run(addressbook=["foo"], target_addressbook=["foo"],
+                             source_search_terms=self.foo,
+                             target_contact=self.bar)
+        self.assertEqual(expected, prepared["foo"])
+
+    def test_no_search_terms_result_in_any_queries(self):
+        expected = query.AnyQuery()
+        prepared = self._run(addressbook=["foo"], target_addressbook=["foo"],
+                             source_search_terms=query.AnyQuery(),
+                             target_contact=query.AnyQuery())
+        self.assertEqual(expected, prepared["foo"])

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,53 +1,52 @@
 import unittest
-from unittest import mock
 
-from khard import query
+from khard.query import AndQuery, AnyQuery, FieldQuery, NullQuery, OrQuery, TermQuery
 
 
 class TestTermQuery(unittest.TestCase):
 
     def test_match_if_query_is_anywhere_in_string(self):
-        q = query.TermQuery('bar')
+        q = TermQuery('bar')
         self.assertTrue(q.match('foo bar baz'))
 
     def test_query_terms_are_case_insensitive(self):
-        q = query.TermQuery('BAR')
+        q = TermQuery('BAR')
         self.assertTrue(q.match('foo bar baz'))
 
     def test_match_arguments_are_case_insensitive(self):
-        q = query.TermQuery('bar')
+        q = TermQuery('bar')
         self.assertTrue(q.match('FOO BAR BAZ'))
 
     def test_match_lists_by_mathing_recursive(self):
-        q = query.TermQuery('bar')
+        q = TermQuery('bar')
         self.assertTrue(q.match(['foo', 'bar baz']))
 
 
 class TestAndQuery(unittest.TestCase):
 
     def test_matches_if_all_subterms_match(self):
-        q1 = query.TermQuery("a")
-        q2 = query.TermQuery("b")
-        q = query.AndQuery(q1, q2)
+        q1 = TermQuery("a")
+        q2 = TermQuery("b")
+        q = AndQuery(q1, q2)
         self.assertTrue(q.match("ab"))
 
     def test_failes_if_at_least_one_subterm_fails(self):
-        q1 = query.TermQuery("a")
-        q2 = query.TermQuery("b")
-        q = query.AndQuery(q1, q2)
+        q1 = TermQuery("a")
+        q2 = TermQuery("b")
+        q = AndQuery(q1, q2)
         self.assertFalse(q.match("ac"))
 
 
 class TestOrQuery(unittest.TestCase):
 
     def test_matches_if_at_least_one_subterm_matchs(self):
-        q1 = query.TermQuery("a")
-        q2 = query.TermQuery("b")
-        q = query.OrQuery(q1, q2)
+        q1 = TermQuery("a")
+        q2 = TermQuery("b")
+        q = OrQuery(q1, q2)
         self.assertTrue(q.match("ac"))
 
     def test_failes_if_all_subterms_fail(self):
-        q1 = query.TermQuery("a")
-        q2 = query.TermQuery("b")
-        q = query.OrQuery(q1, q2)
+        q1 = TermQuery("a")
+        q2 = TermQuery("b")
+        q = OrQuery(q1, q2)
         self.assertFalse(q.match("cd"))

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -50,3 +50,30 @@ class TestOrQuery(unittest.TestCase):
         q2 = TermQuery("b")
         q = OrQuery(q1, q2)
         self.assertFalse(q.match("cd"))
+
+
+class TestEquality(unittest.TestCase):
+
+    def test_any_queries_are_equal(self):
+        self.assertEqual(AnyQuery(), AnyQuery())
+
+    def test_null_queries_are_equal(self):
+        self.assertEqual(NullQuery(), NullQuery())
+
+    def test_or_queries_match_after_sorting(self):
+        null = NullQuery()
+        any = AnyQuery()
+        term = TermQuery("foo")
+        field = FieldQuery("x", "y")
+        first = OrQuery(null, any , term, field)
+        second = OrQuery(any, null, field, term)
+        self.assertEqual(first, second)
+
+    def test_and_queries_match_after_sorting(self):
+        null = NullQuery()
+        any = AnyQuery()
+        term = TermQuery("foo")
+        field = FieldQuery("x", "y")
+        first = AndQuery(null, any , term, field)
+        second = AndQuery(any, null, field, term)
+        self.assertEqual(first, second)

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -17,10 +17,6 @@ class TestTermQuery(unittest.TestCase):
         q = TermQuery('bar')
         self.assertTrue(q.match('FOO BAR BAZ'))
 
-    def test_match_lists_by_mathing_recursive(self):
-        q = TermQuery('bar')
-        self.assertTrue(q.match(['foo', 'bar baz']))
-
 
 class TestAndQuery(unittest.TestCase):
 

--- a/test/test_query.py
+++ b/test/test_query.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest import mock
+
+from khard import query
+
+
+class TestTermQuery(unittest.TestCase):
+
+    def test_match_if_query_is_anywhere_in_string(self):
+        q = query.TermQuery('bar')
+        self.assertTrue(q.match('foo bar baz'))
+
+    def test_query_terms_are_case_insensitive(self):
+        q = query.TermQuery('BAR')
+        self.assertTrue(q.match('foo bar baz'))
+
+    def test_match_arguments_are_case_insensitive(self):
+        q = query.TermQuery('bar')
+        self.assertTrue(q.match('FOO BAR BAZ'))
+
+    def test_match_lists_by_mathing_recursive(self):
+        q = query.TermQuery('bar')
+        self.assertTrue(q.match(['foo', 'bar baz']))
+
+
+class TestAndQuery(unittest.TestCase):
+
+    def test_matches_if_all_subterms_match(self):
+        q1 = query.TermQuery("a")
+        q2 = query.TermQuery("b")
+        q = query.AndQuery(q1, q2)
+        self.assertTrue(q.match("ab"))
+
+    def test_failes_if_at_least_one_subterm_fails(self):
+        q1 = query.TermQuery("a")
+        q2 = query.TermQuery("b")
+        q = query.AndQuery(q1, q2)
+        self.assertFalse(q.match("ac"))
+
+
+class TestOrQuery(unittest.TestCase):
+
+    def test_matches_if_at_least_one_subterm_matchs(self):
+        q1 = query.TermQuery("a")
+        q2 = query.TermQuery("b")
+        q = query.OrQuery(q1, q2)
+        self.assertTrue(q.match("ac"))
+
+    def test_failes_if_all_subterms_fail(self):
+        q1 = query.TermQuery("a")
+        q2 = query.TermQuery("b")
+        q = query.OrQuery(q1, q2)
+        self.assertFalse(q.match("cd"))


### PR DESCRIPTION
This replaces the ad hoc representation that was used to replaces regexes with one defined by a class hirarchy. This can later be used to implement #131.