### PR TITLE
Feature: add-email custom headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ doc/source/api/
 doc/source/examples/template.yaml
 .coverage
 .dmypy.json
+.mypy_cache
+.pytest_cache
+__pycache__
+khard.egg-info

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -87,7 +87,7 @@ class AddressBook(metaclass=abc.ABCMeta):
 
     def _search_names(self, query: Query) -> Generator[
             "carddav_object.CarddavObject", None, None]:
-        """Search in the name filed for contacts matching query.
+        """Search in the name field for contacts matching query.
 
         :param query: the query to search for
         :yields: all found contacts

--- a/khard/cli.py
+++ b/khard/cli.py
@@ -40,6 +40,15 @@ def field_argument(orignal: str) -> List[str]:
     return ret
 
 
+def comma_separated_argument(original: str) -> List[str]:
+    """Return the original string split by commas
+
+    :param original: the value from the command line
+    :returns: the original value split at "," and lower cased
+    """
+    return [f.lower() for f in original.split(",")]
+
+
 def create_parsers() -> Tuple[argparse.ArgumentParser,
                               argparse.ArgumentParser]:
     """Create two argument parsers.
@@ -278,6 +287,14 @@ def create_parsers() -> Tuple[argparse.ArgumentParser,
     add_email_parser.add_argument(
         "--vcard-version", choices=("3.0", "4.0"), dest='preferred_version',
         help="Select preferred vcard version for new contact")
+    add_email_parser.add_argument(
+        "-H",
+        "--headers",
+        dest='fields',
+        default=["from"],
+        type=comma_separated_argument,
+        help="Extract contacts from the given comma separated header fields. \
+                `all` searches all headers.")
     subparsers.add_parser(
         "merge",
         aliases=Actions.get_aliases("merge"),

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -567,7 +567,7 @@ def add_email_subcommand(text: str, abooks: AddressBookCollection) -> None:
     # search for an existing contact
     selected_vcard = choose_vcard_from_list(
         "Select contact for the found e-mail address",
-        get_contact_list_by_user_selection(abooks, name, True))
+        get_contact_list_by_user_selection(abooks, TermQuery(name), True))
     if selected_vcard is None:
         # create new contact
         if not confirm("Contact {} does not exist. Do you want to create it?"

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -543,23 +543,12 @@ def new_subcommand(selected_address_books: AddressBookCollection,
     else:
         create_new_contact(selected_address_book)
 
-
-def add_email_subcommand(text: str, abooks: AddressBookCollection) -> None:
-    """Add a new email address to contacts, creating new contacts if necessary.
+def add_email_to_contact(name: str, email_address: str, abooks: AddressBookCollection) -> None:
+    """Add a new email address to the given contact, creating the contact if necessary.
 
     :param text: the input text to search for the new email
     :param abooks: the addressbooks that were selected on the command line
     """
-    # get name and email address
-    message = message_from_string(text, policy=SMTP_POLICY)
-
-    print("Khard: Add email address to contact")
-    if not message['From'] or not message['From'].addresses:
-        sys.exit("Found no email address")
-
-    email_address = message['From'].addresses[0].addr_spec
-    name = message['From'].addresses[0].display_name
-
     print("Email address: {}".format(email_address))
     if not name:
         name = input("Contact's name: ")
@@ -628,6 +617,25 @@ def add_email_subcommand(text: str, abooks: AddressBookCollection) -> None:
     # save to disk
     selected_vcard.write_to_file(overwrite=True)
     print("Done.\n\n{}".format(selected_vcard.pretty()))
+
+
+def add_email_subcommand(text: str, abooks: AddressBookCollection) -> None:
+    """Add a new email address to contacts, creating new contacts if necessary.
+
+    :param text: the input text to search for the new email
+    :param abooks: the addressbooks that were selected on the command line
+    """
+    # get name and email address
+    message = message_from_string(text, policy=SMTP_POLICY)
+
+    print("Khard: Add email address to contact")
+    if not message['From'] or not message['From'].addresses:
+        sys.exit("Found no email address")
+
+    email_address = message['From'].addresses[0].addr_spec
+    name = message['From'].addresses[0].display_name
+
+    add_email_to_contact(name, email_address, abooks)
 
 
 def birthdays_subcommand(vcard_list: List[CarddavObject], parsable: bool

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -77,3 +77,30 @@ class TestParseArgs(unittest.TestCase):
         args, _config = cli.parse_args(['merge'])
         actual = args.target_contact
         self.assertEqual(expected, actual)
+
+    def test_add_email_defaults_to_from_lowercase(self):
+        args, _config = cli.parse_args(["add-email"])
+        actual = args.fields
+        self.assertEqual(["from"], actual)
+
+    def test_add_email_from_field(self):
+        args, _config = cli.parse_args(["add-email", "-H", "from"])
+        actual = args.fields
+        self.assertEqual(["from"], actual)
+
+    def test_add_email_another_field(self):
+        args, _config = cli.parse_args(["add-email", "-H", "OtHer"])
+        actual = args.fields
+        self.assertEqual(["other"], actual)
+
+    def test_add_email_multiple_headers_separate_args_takes_last(self):
+        args, _config = cli.parse_args(
+            ["add-email", "-H", "OtHer", "-H", "myfield"])
+        actual = args.fields
+        self.assertEqual(["myfield"], actual)
+
+    def test_add_email_multiple_headers_comma_separated(self):
+        args, _config = cli.parse_args(
+            ["add-email", "-H", "OtHer,myfield,from"])
+        actual = args.fields
+        self.assertEqual(["other", "myfield", "from"], actual)


### PR DESCRIPTION
Fixes: https://github.com/scheibler/khard/issues/257

This adds new arguments to the `add-email` sub command, `-H`, `--header` and `--all`, which allow extracting the email addresses from the given header, or all of the headers if requested.

This also adds a loop over the found email addresses so that the user is given the opportunity to add each to a contact.

A later extension of this might allow `-H` and `--header` to accept a list of headers to use, but this isn't implemented here.