### PR TITLE
Expand env vars for addressbooks path config

### DIFF
--- a/doc/source/man/khard.conf.rst
+++ b/doc/source/man/khard.conf.rst
@@ -41,9 +41,10 @@ adressbooks
   This section contains several subsections, but at least one. Each subsection
   can have an arbitrary name which will be the name of an addressbook known to
   khard.  Each of these subsections **must** have a *path* key with the path to
-  the folder containing the vcard files for that addressbook.  :program:`khard`
-  expects the vcard files to hold only one VCARD record each and end in a
-  :file:`.vcf` extension.
+  the folder containing the vcard files for that addressbook.  The *path* value
+  supports environment variables and tilde prefixes.  :program:`khard` expects
+  the vcard files to hold only one VCARD record each and end in a :file:`.vcf`
+  extension.
 
 general
   This section allows one to configure some general features about khard.  The

--- a/doc/source/man/khard.conf.rst
+++ b/doc/source/man/khard.conf.rst
@@ -37,7 +37,7 @@ Options
 
 The config file consists of these four sections:
 
-adressbooks
+addressbooks
   This section contains several subsections, but at least one. Each subsection
   can have an arbitrary name which will be the name of an addressbook known to
   khard.  Each of these subsections **must** have a *path* key with the path to

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -286,8 +286,8 @@ class AddressBookCollection(AddressBook):
     """A collection of several address books.
 
     This represents a temporary merege of the contact collections provided by
-    the underlying address books.  On load all contacts from all
-    subaddressbooks are copied into a dict in this address book.  This allow
+    the underlying address books.  On load, all contacts from all
+    subaddressbooks are copied into a dict in this address book.  This allows
     this class to use all other methods from the parent AddressBook class.
     """
 

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -219,7 +219,7 @@ class VdirAddressBook(AddressBook):
         :param localize_dates: wheater to display dates in the local format
         :param skip: skip unparsable vCard files
         """
-        self.path = os.path.expanduser(path)
+        self.path = os.path.expanduser(os.path.expandvars(path))
         if not os.path.isdir(self.path):
             raise FileNotFoundError("[Errno 2] The path {} to the address book"
                                     " {} does not exist.".format(path, name))

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -11,7 +11,7 @@ from typing import cast, Dict, Generator, Iterator, List, Optional, Union
 import vobject.base
 
 from . import carddav_object
-from.query import AnyQuery, Query
+from .query import AnyQuery, Query
 
 
 logger = logging.getLogger(__name__)

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -216,7 +216,7 @@ class VdirAddressBook(AddressBook):
         :param path: the path to the backing structure on disk
         :param private_objects: the names of private vCard extension fields to
             load
-        :param localize_dates: wheater to display dates in the local format
+        :param localize_dates: whether to display dates in the local format
         :param skip: skip unparsable vCard files
         """
         self.path = os.path.expanduser(os.path.expandvars(path))

--- a/khard/address_book.py
+++ b/khard/address_book.py
@@ -286,9 +286,9 @@ class AddressBookCollection(AddressBook):
     """A collection of several address books.
 
     This represents a temporary merege of the contact collections provided by
-    the underlying adress books.  On load all contacts from all subadressbooks
-    are copied into a dict in this address book.  This allow this class to use
-    all other methods from the parent AddressBook class.
+    the underlying address books.  On load all contacts from all
+    subaddressbooks are copied into a dict in this address book.  This allow
+    this class to use all other methods from the parent AddressBook class.
     """
 
     def __init__(self, name: str, abooks: List[VdirAddressBook]) -> None:

--- a/khard/khard.py
+++ b/khard/khard.py
@@ -817,7 +817,7 @@ def post_address_subcommand(vcard_list: List[CarddavObject], parsable: bool
             list_with_headers(addresses, "Name", "Type", "Post address")
     else:
         if not parsable:
-            print("Found no post adresses")
+            print("Found no post addresses")
         sys.exit(1)
 
 

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -122,21 +122,21 @@ class VcardAddressBookLoad(unittest.TestCase):
             'test could not be parsed.')
 
     @mock.patch.dict("os.environ", clear=True)
-    def test_no_expand_unset_env_var(self):
+    def test_do_not_expand_env_var_that_is_unset(self):
         # Unset env vars shouldn't expand.
         with self.assertRaises(FileNotFoundError):
             address_book.VdirAddressBook(
                 "test", "test/fixture/test.abook${}".format("KHARD_FOO"))
 
     @mock.patch.dict("os.environ", KHARD_FOO="")
-    def test_expand_set_env_var_empty(self):
+    def test_expand_env_var_that_is_empty(self):
         # Env vars set to empty string should expand to empty string.
         abook = address_book.VdirAddressBook(
             "test", "test/fixture/test.abook${}".format("KHARD_FOO"))
         self.assertEqual(abook.path, "test/fixture/test.abook")
 
     @mock.patch.dict("os.environ", KHARD_FOO="test/fixture")
-    def test_expand_set_env_var_nonempty(self):
+    def test_expand_env_var_that_is_nonempty(self):
         # Env vars set to nonempty string should expand appropriately.
         abook = address_book.VdirAddressBook(
             "test", "${}/test.abook".format("KHARD_FOO"))

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -123,15 +123,10 @@ class VcardAddressBookLoad(unittest.TestCase):
 
     @mock.patch.dict("os.environ", clear=True)
     def test_no_expand_unset_env_var(self):
-        var_name = "KHARD_FOO"
         # Unset env vars shouldn't expand.
-        try:
+        with self.assertRaises(FileNotFoundError):
             address_book.VdirAddressBook(
-                "test", "test/fixture/test.abook${}".format(var_name))
-            self.assertTrue(False)
-        except FileNotFoundError as err:
-            self.assertIn("test/fixture/test.abook${}".format(var_name),
-                          err.args[0])
+                "test", "test/fixture/test.abook${}".format("KHARD_FOO"))
 
     @mock.patch.dict("os.environ", KHARD_FOO="")
     def test_expand_set_env_var_empty(self):

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -131,14 +131,16 @@ class VcardAddressBookLoad(unittest.TestCase):
     @mock.patch.dict("os.environ", KHARD_FOO="")
     def test_expand_set_env_var_empty(self):
         # Env vars set to empty string should expand to empty string.
-        address_book.VdirAddressBook(
+        abook = address_book.VdirAddressBook(
             "test", "test/fixture/test.abook${}".format("KHARD_FOO"))
+        self.assertEqual(abook.path, "test/fixture/test.abook")
 
     @mock.patch.dict("os.environ", KHARD_FOO="test/fixture")
     def test_expand_set_env_var_nonempty(self):
         # Env vars set to nonempty string should expand appropriately.
-        address_book.VdirAddressBook(
+        abook = address_book.VdirAddressBook(
             "test", "${}/test.abook".format("KHARD_FOO"))
+        self.assertEqual(abook.path, "test/fixture/test.abook")
 
 
 class AddressBookGetShortUidDict(unittest.TestCase):

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -19,7 +19,7 @@ class _AddressBook(address_book.AddressBook):
 class AbstractAddressBookSearch(unittest.TestCase):
     """Tests for khard.address_book.AddressBook.search()"""
 
-    def test_invalide_method_failes(self):
+    def test_invalid_method_fails(self):
         abook = _AddressBook('test')
         with self.assertRaises(ValueError):
             abook.search('query', method='invalid_method')
@@ -70,7 +70,7 @@ class AddressBookCompareUids(unittest.TestCase):
         self.assertEqual(actual, expected)
 
 
-class VcardAdressBookLoad(unittest.TestCase):
+class VcardAddressBookLoad(unittest.TestCase):
 
     def test_vcards_without_uid_generate_a_warning(self):
         abook = address_book.VdirAddressBook('test',

--- a/test/test_address_book.py
+++ b/test/test_address_book.py
@@ -121,12 +121,10 @@ class VcardAddressBookLoad(unittest.TestCase):
             'WARNING:khard.address_book:1 of 1 vCard files of address book '
             'test could not be parsed.')
 
-    def test_env_var_paths(self):
+    @mock.patch.dict("os.environ", clear=True)
+    def test_no_expand_unset_env_var(self):
         var_name = "KHARD_FOO"
-
         # Unset env vars shouldn't expand.
-        if var_name in os.environ:
-            os.environ.pop(var_name)
         try:
             address_book.VdirAddressBook(
                 "test", "test/fixture/test.abook${}".format(var_name))
@@ -135,15 +133,17 @@ class VcardAddressBookLoad(unittest.TestCase):
             self.assertIn("test/fixture/test.abook${}".format(var_name),
                           err.args[0])
 
+    @mock.patch.dict("os.environ", KHARD_FOO="")
+    def test_expand_set_env_var_empty(self):
         # Env vars set to empty string should expand to empty string.
-        os.environ[var_name] = ""
         address_book.VdirAddressBook(
-            "test", "test/fixture/test.abook${}".format(var_name))
+            "test", "test/fixture/test.abook${}".format("KHARD_FOO"))
 
+    @mock.patch.dict("os.environ", KHARD_FOO="test/fixture")
+    def test_expand_set_env_var_nonempty(self):
         # Env vars set to nonempty string should expand appropriately.
-        os.environ[var_name] = "test/fixture"
         address_book.VdirAddressBook(
-            "test", "${}/test.abook".format(var_name))
+            "test", "${}/test.abook".format("KHARD_FOO"))
 
 
 class AddressBookGetShortUidDict(unittest.TestCase):

--- a/test/test_command_line_interface.py
+++ b/test/test_command_line_interface.py
@@ -421,7 +421,7 @@ class CommandLineDefaultsDoNotOverwriteConfigValues(unittest.TestCase):
 
 
 @mock.patch.dict('os.environ', KHARD_CONFIG='test/fixture/minimal.conf')
-class CommandLineArguemtsOverwriteConfigValues(unittest.TestCase):
+class CommandLineArgumentsOverwriteConfigValues(unittest.TestCase):
 
     @staticmethod
     def _merge(args):


### PR DESCRIPTION
Expand environment variables for the `addressbooks.<name>.path` config
values.  With this, you can set an addressbook path to
`$XDG_DATA_HOME/contacts/foo`, for example.

This may be backwards incompatible for users that use literal dollar
characters (`$`) in their paths.  If the environment variable expansion
is possible, it will be unintentionally expanded.  If it is not
possible, however, it will not be expanded.  So the compatibility issue
is only when the path is expandable (e.g.
`~/classes/english/$LANG/contacts`).  With this change, I do not know of
a way to express these kinds of paths (escaping doesn't work).  Yet, I
doubt anyone would come across this issue, let alone have a literal
dollar sign in their path.