### PR TITLE
Fix minor error in VCardWrapper.__init__() warning

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -115,7 +115,7 @@ class VCardWrapper:
         elif self.version not in self._supported_versions:
             logger.warning("Wrapping vCard with unsupported version %s, this "
                            "might change any incompatible attributes.",
-                           version)
+                           self.version)
 
     def __str__(self) -> str:
         return self.formatted_name


### PR DESCRIPTION
While having a quick look at #279 I noticed that this block tests `self.version` but prints `version`.