### PR TITLE
Quickfix for no method error (validate)

### DIFF
--- a/khard/config.py
+++ b/khard/config.py
@@ -9,7 +9,11 @@ import shlex
 from typing import Iterable, Dict, List, Optional, Union
 
 import configobj
-from configobj import validate
+try:
+    # since configobj 5.1
+    from configobj import validate
+except ImportError:
+    import validate
 
 from .actions import Actions
 from .address_book import AddressBookCollection, AddressBookNameError, \

--- a/khard/config.py
+++ b/khard/config.py
@@ -9,7 +9,7 @@ import shlex
 from typing import Iterable, Dict, List, Optional, Union
 
 import configobj
-import validate
+from configobj import validate
 
 from .actions import Actions
 from .address_book import AddressBookCollection, AddressBookNameError, \


### PR DESCRIPTION
After updating khard/khal stopped working for me. Adjusting the import fixed this issue for me.