### PR TITLE
Reduce empty address lines in "details" output

### DIFF
--- a/khard/carddav_object.py
+++ b/khard/carddav_object.py
@@ -794,6 +794,12 @@ class VCardWrapper:
             for post_adr in post_adr_list:
                 get: Callable[[str], str] = lambda name: list_to_string(
                     post_adr.get(name, ""), " ")
+
+                # remove empty fields to avoid empty lines
+                for x in list(post_adr.keys()):
+                    if post_adr.get(x) == "":
+                        del post_adr[x]
+
                 strings = []
                 if "street" in post_adr:
                     strings.append(list_to_string(


### PR DESCRIPTION
When formatting the postal address, empty fields cause empty lines and sometimes weird appearance.
For example:
````
Address
    HOME: 
        Main street 20

        1234 AB Blaricum
        , Netherlands
````
This PR removes empty fields from the address structure so they do not cause misbehaviour.

After the patch:
````
Address
    HOME: 
        Main street 20
        1234 AB Blaricum
        Netherlands
````
