### PR TITLE
docs: clarify that khard does not speak CardDAV

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ khard
 =====
 
 Khard is an address book for the Unix console. It creates, reads, modifies and
-removes carddav address book entries at your local machine. Khard is also
+removes vCard address book entries at your local machine. Khard is also
 compatible to the email clients mutt and alot and the SIP client twinkle. You
 can find more information about khard and the whole synchronization process
 [here][blog].

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -134,7 +134,7 @@ htmlhelp_basename = 'kharddoc'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('man/khard', 'khard', 'Console carddav client', '', 1),
+    ('man/khard', 'khard', 'Console address book manager', '', 1),
     ('man/khard.conf', 'khard.conf', 'configuration file for khard', '', 5),
 ]
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -13,8 +13,8 @@ Welcome to khard's documentation!
    indices
 
 Khard is an address book for the Unix command line.  It can read, create,
-modify and delete carddav address book entries.  Khard only works with a local
-store of VCARD files.  It is intended to be used in conjunction with other
+modify and delete vCard address book entries.  Khard only works with a local
+store of vCard files.  It is intended to be used in conjunction with other
 programs like an email client, text editor, vdir synchronizer or VOIP client.
 
 

--- a/doc/source/man/khard.rst
+++ b/doc/source/man/khard.rst
@@ -14,8 +14,8 @@ Description
 -----------
 
 :program:`khard` is an address book for the Unix command line.  It can read, create,
-modify and delete carddav address book entries.  :program:`khard` only works with a local
-store of VCARD files.  It is intended to be used in conjunction with other
+modify and delete vCard address book entries.  :program:`khard` only works with a local
+store of vCard files.  It is intended to be used in conjunction with other
 programs like an email client, text editor, vdir synchronizer or VOIP client.
 
 Options

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,11 @@ setup(
     author='Eric Scheibler',
     author_email='email@eric-scheibler.de',
     url='https://github.com/scheibler/khard/',
-    description='A console carddav client',
+    description='A console address book manager',
     long_description=readme,
     long_description_content_type='text/markdown',
     license='GPL',
-    keywords='Carddav console addressbook',
+    keywords='vcard console addressbook',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Console",


### PR DESCRIPTION
Just to avoid some frustration for folks that found khard when looking
for a CardDAV client.

Note: CardDAV is also used throughout the code, but I don't think that
that's how people find khard. The important parts are the README and the
docs, and the description in `setup.py`.

Fixes: #303